### PR TITLE
order output parameters and hide urls when not really running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+  - Only show deployment URLs when number of running replicas is positive
+  - Order output parameters alphabetically
   - Dependencies - Update shadow-cljs to version 2.8.45
   - Sidebar - Css scroll y set to auto to support paysage mode
   - Apps project - pageheader inline display

--- a/code/src/cljs/sixsq/nuvla/ui/dashboard/subs.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/dashboard/subs.cljs
@@ -2,7 +2,8 @@
   (:require
     [re-frame.core :refer [reg-sub]]
     [sixsq.nuvla.ui.dashboard.spec :as spec]
-    [sixsq.nuvla.ui.dashboard.utils :as utils]))
+    [sixsq.nuvla.ui.dashboard.utils :as utils]
+    [sixsq.nuvla.ui.dashboard.utils :as dashboard-utils]))
 
 
 (reg-sub
@@ -59,4 +60,5 @@
     (let [deployment-params-by-name (->> (get deployments-params-map id)
                                          (map (juxt :name identity))
                                          (into {}))]
-      (utils/resolve-url-pattern url-pattern deployment-params-by-name))))
+      (when (dashboard-utils/running-replica? deployment-params-by-name)
+        (utils/resolve-url-pattern url-pattern deployment-params-by-name)))))

--- a/code/src/cljs/sixsq/nuvla/ui/dashboard/subs.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/dashboard/subs.cljs
@@ -2,8 +2,7 @@
   (:require
     [re-frame.core :refer [reg-sub]]
     [sixsq.nuvla.ui.dashboard.spec :as spec]
-    [sixsq.nuvla.ui.dashboard.utils :as utils]
-    [sixsq.nuvla.ui.dashboard.utils :as dashboard-utils]))
+    [sixsq.nuvla.ui.dashboard.utils :as utils]))
 
 
 (reg-sub
@@ -60,5 +59,5 @@
     (let [deployment-params-by-name (->> (get deployments-params-map id)
                                          (map (juxt :name identity))
                                          (into {}))]
-      (when (dashboard-utils/running-replica? deployment-params-by-name)
+      (when (utils/running-replica? deployment-params-by-name)
         (utils/resolve-url-pattern url-pattern deployment-params-by-name)))))

--- a/code/src/cljs/sixsq/nuvla/ui/dashboard/utils.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/dashboard/utils.cljs
@@ -23,6 +23,16 @@
           url-pattern pattern-value)))))
 
 
+(defn running-replica?
+  "Extracts the number of running replicas and returns true if the number is
+   positive. Returns false is all other cases."
+  [deployment-parameters]
+  (let [n (some->> (get deployment-parameters "replicas.running")
+                   :value
+                   general-utils/str->int)]
+    (and (number? n) (pos? n))))
+
+
 (defn deployment-active?
   [state]
   (str/ends-with? (str state) "ING"))

--- a/code/src/cljs/sixsq/nuvla/ui/dashboard_detail/subs.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/dashboard_detail/subs.cljs
@@ -46,7 +46,9 @@
 (reg-sub
   ::deployment-parameters
   (fn [db]
-    (::spec/deployment-parameters db)))
+    (->> db
+         ::spec/deployment-parameters
+         (sort-by :name))))
 
 
 (reg-sub

--- a/code/src/cljs/sixsq/nuvla/ui/dashboard_detail/subs.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/dashboard_detail/subs.cljs
@@ -49,9 +49,9 @@
     (::spec/deployment-parameters db)))
 
 
-
 (reg-sub
   ::url
   :<- [::deployment-parameters]
   (fn [deployment-parameters [_ url-pattern]]
-    (dashboard-utils/resolve-url-pattern url-pattern deployment-parameters)))
+    (when (dashboard-utils/running-replica? deployment-parameters)
+      (dashboard-utils/resolve-url-pattern url-pattern deployment-parameters))))

--- a/code/src/cljs/sixsq/nuvla/ui/dashboard_detail/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/dashboard_detail/views.cljs
@@ -102,7 +102,7 @@
              [ui/TableHeaderCell [:span (@tr [:value])]]]]
            (when-not (empty? params)
              [ui/TableBody
-              (for [{param-name :name :as param} (sort-by :name params)]
+              (for [{param-name :name :as param} params]
                 ^{:key param-name}
                 [parameter-to-row param])])]]
          :count (count params)

--- a/code/src/cljs/sixsq/nuvla/ui/dashboard_detail/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/dashboard_detail/views.cljs
@@ -102,7 +102,7 @@
              [ui/TableHeaderCell [:span (@tr [:value])]]]]
            (when-not (empty? params)
              [ui/TableBody
-              (for [{param-name :name :as param} params]
+              (for [{param-name :name :as param} (sort-by :name params)]
                 ^{:key param-name}
                 [parameter-to-row param])])]]
          :count (count params)


### PR DESCRIPTION
Use the number of running replicas to decide whether to show the URL or not.  The number of running replicas must be positive.

Put the output parameters in alphabetical order.
