### PR TITLE
fix output parameter ordering

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/dashboard_detail/subs.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/dashboard_detail/subs.cljs
@@ -48,7 +48,7 @@
   (fn [db]
     (->> db
          ::spec/deployment-parameters
-         (sort-by :name))))
+         (into (sorted-map)))))
 
 
 (reg-sub


### PR DESCRIPTION
Fix the ordering of the output parameters. Do this in the subscription so that all functions that use the data have the same ordered map.