### PR TITLE
add action buttons to peripheral accordions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  - Egde - Automatic NuvlaBox release selection and peripheral correlation
  - Edge - Dynamic compose file generation upon NuvlaBox creation
  - Edge - Installation guides upon NuvlaBox creation
+ - Edge - Action buttons to peripherals
 
 ### Changed
 

--- a/code/src/cljs/sixsq/nuvla/ui/edge_detail/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/edge_detail/events.cljs
@@ -40,7 +40,7 @@
              ::cimi-api-fx/search [:nuvlabox-peripheral
                                    {:filter  (str "parent='" id "'")
                                     :last    10000
-                                    :orderby "id"}
+                                    :orderby "updated:desc"}
                                    #(dispatch [::set-nuvlabox-peripherals %])]}
             (not= (:id nuvlabox) id) (assoc :db (merge db spec/defaults)))))
 
@@ -77,3 +77,22 @@
   (fn [{{:keys [::spec/nuvlabox]} :db} _]
     (let [nuvlabox-id (:id nuvlabox)]
       {::cimi-api-fx/delete [nuvlabox-id #(dispatch [::history-events/navigate "edge"])]})))
+
+
+(reg-event-fx
+  ::custom-action
+  (fn [_ [_ resource-id operation success-msg]]
+    {::cimi-api-fx/operation [resource-id operation
+                         #(if (instance? js/Error %)
+                            (let [{:keys [status message]} (response/parse-ex-info %)]
+                              (dispatch [::messages-events/add
+                                         {:header  (cond-> (str "error on operation " operation " for " resource-id)
+                                                     status (str " (" status ")"))
+                                          :content message
+                                          :type    :error}]))
+
+                              (when success-msg
+                                (dispatch [::messages-events/add
+                                           {:header  success-msg
+                                            :content success-msg
+                                            :type    :success}])))]}))

--- a/code/src/cljs/sixsq/nuvla/ui/edge_detail/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/edge_detail/events.cljs
@@ -19,7 +19,9 @@
 (reg-event-db
   ::set-nuvlabox-peripherals
   (fn [db [_ nuvlabox-peripherals]]
-    (assoc db ::spec/nuvlabox-peripherals (get nuvlabox-peripherals :resources []))))
+    (assoc db ::spec/nuvlabox-peripherals (->> (get nuvlabox-peripherals :resources [])
+                                               (map (juxt :id identity))
+                                               (into {})))))
 
 
 (reg-event-fx
@@ -40,7 +42,7 @@
              ::cimi-api-fx/search [:nuvlabox-peripheral
                                    {:filter  (str "parent='" id "'")
                                     :last    10000
-                                    :orderby "updated:desc"}
+                                    :orderby "id"}
                                    #(dispatch [::set-nuvlabox-peripherals %])]}
             (not= (:id nuvlabox) id) (assoc :db (merge db spec/defaults)))))
 
@@ -66,9 +68,9 @@
                             (do
                               (when success-msg
                                 (dispatch [::messages-events/add
-                                          {:header  success-msg
-                                           :content success-msg
-                                           :type    :success}]))
+                                           {:header  success-msg
+                                            :content success-msg
+                                            :type    :success}]))
                               (dispatch [::set-nuvlabox %])))]}))
 
 
@@ -83,16 +85,16 @@
   ::custom-action
   (fn [_ [_ resource-id operation success-msg]]
     {::cimi-api-fx/operation [resource-id operation
-                         #(if (instance? js/Error %)
-                            (let [{:keys [status message]} (response/parse-ex-info %)]
-                              (dispatch [::messages-events/add
-                                         {:header  (cond-> (str "error on operation " operation " for " resource-id)
-                                                     status (str " (" status ")"))
-                                          :content message
-                                          :type    :error}]))
+                              #(if (instance? js/Error %)
+                                 (let [{:keys [status message]} (response/parse-ex-info %)]
+                                   (dispatch [::messages-events/add
+                                              {:header  (cond-> (str "error on operation " operation " for " resource-id)
+                                                                status (str " (" status ")"))
+                                               :content message
+                                               :type    :error}]))
 
-                              (when success-msg
-                                (dispatch [::messages-events/add
-                                           {:header  success-msg
-                                            :content success-msg
-                                            :type    :success}])))]}))
+                                 (when success-msg
+                                   (dispatch [::messages-events/add
+                                              {:header  success-msg
+                                               :content success-msg
+                                               :type    :success}])))]}))

--- a/code/src/cljs/sixsq/nuvla/ui/edge_detail/subs.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/edge_detail/subs.cljs
@@ -23,6 +23,19 @@
   (fn [db]
     (::spec/nuvlabox-peripherals db)))
 
+(reg-sub
+  ::nuvlabox-peripherals-ids
+  :<- [::nuvlabox-peripherals]
+  (fn [nuvlabox-peripherals]
+    (keys nuvlabox-peripherals)))
+
+
+(reg-sub
+  ::nuvlabox-peripheral
+  :<- [::nuvlabox-peripherals]
+  (fn [nuvlabox-peripherals [_ id]]
+    (get nuvlabox-peripherals id)))
+
 
 (reg-sub
   ::next-heartbeat-moment

--- a/code/src/cljs/sixsq/nuvla/ui/edge_detail/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/edge_detail/views.cljs
@@ -110,7 +110,7 @@
              p-data-sample :raw-data-sample} @peripheral
             actions (get-available-actions p-ops)]
 
-        (when (> p-updated @last-updated)
+        (when (> (compare p-updated @last-updated) 0)
           (reset! button-load? false)
           (reset! last-updated p-updated))
         [uix/Accordion

--- a/code/src/cljs/sixsq/nuvla/ui/edge_detail/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/edge_detail/views.cljs
@@ -85,131 +85,131 @@
 
 
 (defn Peripheral
-  [{p-id          :id
-    p-ops         :operations
-    p-name        :name
-    p-product     :product
-    p-created     :created
-    p-updated     :updated
-    p-descr       :description
-    p-interface   :interface
-    p-device-path :device-path
-    p-available   :available
-    p-vendor      :vendor
-    p-classes     :classes
-    p-identifier  :identifier
-    p-serial-num  :serial-number
-    p-video-dev   :video-device
-    p-data-gw-url :local-data-gateway-endpoint
-    p-data-sample :raw-data-sample}]
-  (let [locale  (subscribe [::i18n-subs/locale])
-        actions (get-available-actions p-ops)
-        button-load? (r/atom false)]
-    (fn []
-      [uix/Accordion
-       [ui/Table {:basic "very"}
-        [ui/TableBody
-         (when p-product
+  [id]
+  (let [locale       (subscribe [::i18n-subs/locale])
+        button-load? (r/atom false)
+        peripheral   (subscribe [::subs/nuvlabox-peripheral id])]
+    (fn [id]
+      (let [{p-id          :id
+             p-ops         :operations
+             p-name        :name
+             p-product     :product
+             p-created     :created
+             p-updated     :updated
+             p-descr       :description
+             p-interface   :interface
+             p-device-path :device-path
+             p-available   :available
+             p-vendor      :vendor
+             p-classes     :classes
+             p-identifier  :identifier
+             p-serial-num  :serial-number
+             p-video-dev   :video-device
+             p-data-gw-url :local-data-gateway-endpoint
+             p-data-sample :raw-data-sample} @peripheral
+            actions (get-available-actions p-ops)]
+        [uix/Accordion
+         [ui/Table {:basic "very"}
+          [ui/TableBody
+           (when p-product
+             [ui/TableRow
+              [ui/TableCell "Name"]
+              [ui/TableCell (str p-name " " p-product)]])
+           (when p-serial-num
+             [ui/TableRow
+              [ui/TableCell "Serial Number"]
+              [ui/TableCell p-serial-num]])
+           (when p-descr
+             [ui/TableRow
+              [ui/TableCell "Description"]
+              [ui/TableCell p-descr]])
            [ui/TableRow
-            [ui/TableCell "Name"]
-            [ui/TableCell (str p-name " " p-product)]])
-         (when p-serial-num
+            [ui/TableCell "Classes"]
+            [ui/TableCell (str/join ", " p-classes)]]
            [ui/TableRow
-            [ui/TableCell "Serial Number"]
-            [ui/TableCell p-serial-num]])
-         (when p-descr
+            [ui/TableCell "Available"]
+            [ui/TableCell
+             [ui/Icon {:name "circle", :color (if p-available "green" "red")}]
+             (if p-available "Yes" "No")]]
+           (when p-interface
+             [ui/TableRow
+              [ui/TableCell "Interface"]
+              [ui/TableCell p-interface]])
+           (when p-device-path
+             [ui/TableRow
+              [ui/TableCell "Device Path"]
+              [ui/TableCell p-device-path]])
+           (when p-video-dev
+             [ui/TableRow
+              [ui/TableCell "Video Device"]
+              [ui/TableCell p-video-dev]])
            [ui/TableRow
-            [ui/TableCell "Description"]
-            [ui/TableCell p-descr]])
-         [ui/TableRow
-          [ui/TableCell "Classes"]
-          [ui/TableCell (str/join ", " p-classes)]]
-         [ui/TableRow
-          [ui/TableCell "Available"]
-          [ui/TableCell
-           [ui/Icon {:name "circle", :color (if p-available "green" "red")}]
-           (if p-available "Yes" "No")]]
-         (when p-interface
+            [ui/TableCell "Identifier"]
+            [ui/TableCell p-identifier]]
            [ui/TableRow
-            [ui/TableCell "Interface"]
-            [ui/TableCell p-interface]])
-         (when p-device-path
+            [ui/TableCell "Vendor"]
+            [ui/TableCell p-vendor]]
            [ui/TableRow
-            [ui/TableCell "Device Path"]
-            [ui/TableCell p-device-path]])
-         (when p-video-dev
+            [ui/TableCell "Created"]
+            [ui/TableCell (time/ago (time/parse-iso8601 p-created) @locale)]]
            [ui/TableRow
-            [ui/TableCell "Video Device"]
-            [ui/TableCell p-video-dev]])
-         [ui/TableRow
-          [ui/TableCell "Identifier"]
-          [ui/TableCell p-identifier]]
-         [ui/TableRow
-          [ui/TableCell "Vendor"]
-          [ui/TableCell p-vendor]]
-         [ui/TableRow
-          [ui/TableCell "Created"]
-          [ui/TableCell (time/ago (time/parse-iso8601 p-created) @locale)]]
-         [ui/TableRow
-          [ui/TableCell "Updated"]
-          [ui/TableCell (time/ago (time/parse-iso8601 p-updated) @locale)]]
-         (when p-data-gw-url
-           [ui/TableRow {:positive true}
-            [ui/TableCell "Data Gateway Connection"]
-            [ui/TableCell p-data-gw-url]])
-         (when p-data-sample
-           [ui/TableRow {:positive true}
-            [ui/TableCell "Raw Data Sample"]
-            [ui/TableCell p-data-sample]])]
-        (when (> (count actions) 0)
-          [ui/TableFooter
-           [ui/TableRow
-            [ui/TableHeaderCell [:span (true? @button-load?)]]
-            [ui/TableHeaderCell
-             [ui/Popup
-              {:position "left center"
-               :content  "Click to start/stop routing this peripheral's data through the Data Gateway"
-               :header   "data-gateway"
-               :inverted true
-               :wide     "very"
-               :size     "small"
-               :trigger  (r/as-element
-                           [ui/Button {:on-click #(do
-                                                    (swap! button-load? not)
-                                                    (dispatch
-                                                      [::events/custom-action p-id (first actions)
-                                                       (str "Triggered " (first actions) " for " p-id)]))
-                                       :floated "right"
-                                       :color   "vk"
-                                       :size    "large"
-                                       :circular true
-                                       :disabled @button-load?
-                                       :loading  @button-load?}
-                            (first actions)])}]
-             ]]])]
-       :label (or p-name p-product)
-       :title-size :h4
-       :default-open false
-       :icon (case p-interface
-               "USB" "usb"
-               nil)])))
+            [ui/TableCell "Updated"]
+            [ui/TableCell (time/ago (time/parse-iso8601 p-updated) @locale)]]
+           (when p-data-gw-url
+             [ui/TableRow {:positive true}
+              [ui/TableCell "Data Gateway Connection"]
+              [ui/TableCell p-data-gw-url]])
+           (when p-data-sample
+             [ui/TableRow {:positive true}
+              [ui/TableCell "Raw Data Sample"]
+              [ui/TableCell p-data-sample]])]
+          (when (> (count actions) 0)
+            [ui/TableFooter
+             [ui/TableRow
+              [ui/TableHeaderCell [:span (true? @button-load?)]]
+              [ui/TableHeaderCell
+               [ui/Popup
+                {:position "left center"
+                 :content  "Click to start/stop routing this peripheral's data through the Data Gateway"
+                 :header   "data-gateway"
+                 :inverted true
+                 :wide     "very"
+                 :size     "small"
+                 :trigger  (r/as-element
+                             [ui/Button {:on-click #(do
+                                                      (swap! button-load? not)
+                                                      (dispatch
+                                                        [::events/custom-action p-id (first actions)
+                                                         (str "Triggered " (first actions) " for " p-id)]))
+                                         :floated  "right"
+                                         :color    "vk"
+                                         :size     "large"
+                                         :circular true
+                                         :disabled @button-load?
+                                         :loading  @button-load?}
+                              (first actions)])}]
+               ]]])]
+         :label (or p-name p-product)
+         :title-size :h4
+         :default-open false
+         :icon (case p-interface
+                 "USB" "usb"
+                 nil)]))))
 
 
 (defn Peripherals
   []
-  (let [nuvlabox-peripherals (subscribe [::subs/nuvlabox-peripherals])]
+  (let [ids (subscribe [::subs/nuvlabox-peripherals-ids])]
     (fn []
-    [uix/Accordion
-     [:div
-      (doall
-        (for [{p-identifier  :identifier
-               p-updated     :updated
-               :as           peripheral} @nuvlabox-peripherals]
-          ^{:key (str p-identifier p-updated)}
-          [Peripheral peripheral]))]
-     :label "Peripherals"
-     :icon "usb"
-     :count (count @nuvlabox-peripherals)])))
+      [uix/Accordion
+       [:div
+        (doall
+          (for [id @ids]
+            ^{:key id}
+            [Peripheral id]))]
+       :label "Peripherals"
+       :icon "usb"
+       :count (count @ids)])))
 
 
 (defn LocationAccordion

--- a/code/src/cljs/sixsq/nuvla/ui/edge_detail/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/edge_detail/views.cljs
@@ -183,6 +183,7 @@
                                        :color   "vk"
                                        :size    "large"
                                        :circular true
+                                       :disabled @button-load?
                                        :loading  @button-load?}
                             (first actions)])}]
              ]]])]

--- a/code/src/cljs/sixsq/nuvla/ui/edge_detail/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/edge_detail/views.cljs
@@ -87,8 +87,8 @@
 (defn Peripheral
   [id]
   (let [locale       (subscribe [::i18n-subs/locale])
-        last-updated (r/atom {:updated "1970-01-01T00:00:00Z"})
-        button-load? (r/atom true)
+        last-updated (r/atom "1970-01-01T00:00:00Z")
+        button-load? (r/atom false)
         peripheral   (subscribe [::subs/nuvlabox-peripheral id])]
     (fn [id]
       (let [{p-id          :id
@@ -109,98 +109,97 @@
              p-data-gw-url :local-data-gateway-endpoint
              p-data-sample :raw-data-sample} @peripheral
             actions (get-available-actions p-ops)]
-        (doall
-          (when (> p-updated (:updated @last-updated))
-            (doall
-              (swap! button-load? not)
-              (swap! last-updated assoc :updated p-updated)))
-          [uix/Accordion
-           [ui/Table {:basic "very"}
-            [ui/TableBody
-             (when p-product
-               [ui/TableRow
-                [ui/TableCell "Name"]
-                [ui/TableCell (str p-name " " p-product)]])
-             (when p-serial-num
-               [ui/TableRow
-                [ui/TableCell "Serial Number"]
-                [ui/TableCell p-serial-num]])
-             (when p-descr
-               [ui/TableRow
-                [ui/TableCell "Description"]
-                [ui/TableCell p-descr]])
+
+        (when (> p-updated @last-updated)
+          (reset! button-load? false)
+          (reset! last-updated p-updated))
+        [uix/Accordion
+         [ui/Table {:basic "very"}
+          [ui/TableBody
+           (when p-product
              [ui/TableRow
-              [ui/TableCell "Classes"]
-              [ui/TableCell (str/join ", " p-classes)]]
+              [ui/TableCell "Name"]
+              [ui/TableCell (str p-name " " p-product)]])
+           (when p-serial-num
              [ui/TableRow
-              [ui/TableCell "Available"]
-              [ui/TableCell
-               [ui/Icon {:name "circle", :color (if p-available "green" "red")}]
-               (if p-available "Yes" "No")]]
-             (when p-interface
-               [ui/TableRow
-                [ui/TableCell "Interface"]
-                [ui/TableCell p-interface]])
-             (when p-device-path
-               [ui/TableRow
-                [ui/TableCell "Device Path"]
-                [ui/TableCell p-device-path]])
-             (when p-video-dev
-               [ui/TableRow
-                [ui/TableCell "Video Device"]
-                [ui/TableCell p-video-dev]])
+              [ui/TableCell "Serial Number"]
+              [ui/TableCell p-serial-num]])
+           (when p-descr
              [ui/TableRow
-              [ui/TableCell "Identifier"]
-              [ui/TableCell p-identifier]]
+              [ui/TableCell "Description"]
+              [ui/TableCell p-descr]])
+           [ui/TableRow
+            [ui/TableCell "Classes"]
+            [ui/TableCell (str/join ", " p-classes)]]
+           [ui/TableRow
+            [ui/TableCell "Available"]
+            [ui/TableCell
+             [ui/Icon {:name "circle", :color (if p-available "green" "red")}]
+             (if p-available "Yes" "No")]]
+           (when p-interface
              [ui/TableRow
-              [ui/TableCell "Vendor"]
-              [ui/TableCell p-vendor]]
+              [ui/TableCell "Interface"]
+              [ui/TableCell p-interface]])
+           (when p-device-path
              [ui/TableRow
-              [ui/TableCell "Created"]
-              [ui/TableCell (time/ago (time/parse-iso8601 p-created) @locale)]]
+              [ui/TableCell "Device Path"]
+              [ui/TableCell p-device-path]])
+           (when p-video-dev
              [ui/TableRow
-              [ui/TableCell "Updated"]
-              [ui/TableCell (time/ago (time/parse-iso8601 p-updated) @locale)]]
-             (when p-data-gw-url
-               [ui/TableRow {:positive true}
-                [ui/TableCell "Data Gateway Connection"]
-                [ui/TableCell p-data-gw-url]])
-             (when p-data-sample
-               [ui/TableRow {:positive true}
-                [ui/TableCell "Raw Data Sample"]
-                [ui/TableCell p-data-sample]])]
-            (when (> (count actions) 0)
-              [ui/TableFooter
-               [ui/TableRow
-                [ui/TableHeaderCell]
-                [ui/TableHeaderCell
-                 [ui/Popup
-                  {:position "left center"
-                   :content  "Click to start/stop routing this peripheral's data through the Data Gateway"
-                   :header   "data-gateway"
-                   :inverted true
-                   :wide     "very"
-                   :size     "small"
-                   :trigger  (r/as-element
-                               [ui/Button {:on-click #(do
-                                                        (swap! button-load? not)
-                                                        (dispatch
-                                                          [::events/custom-action p-id (first actions)
-                                                           (str "Triggered " (first actions) " for " p-id)]))
-                                           :floated  "right"
-                                           :color    "vk"
-                                           :size     "large"
-                                           :circular true
-                                           :disabled @button-load?
-                                           :loading  @button-load?}
-                                @last-updated])}]
-                 ]]])]
-           :label (or p-name p-product)
-           :title-size :h4
-           :default-open false
-           :icon (case p-interface
-                   "USB" "usb"
-                   nil)])))))
+              [ui/TableCell "Video Device"]
+              [ui/TableCell p-video-dev]])
+           [ui/TableRow
+            [ui/TableCell "Identifier"]
+            [ui/TableCell p-identifier]]
+           [ui/TableRow
+            [ui/TableCell "Vendor"]
+            [ui/TableCell p-vendor]]
+           [ui/TableRow
+            [ui/TableCell "Created"]
+            [ui/TableCell (time/ago (time/parse-iso8601 p-created) @locale)]]
+           [ui/TableRow
+            [ui/TableCell "Updated"]
+            [ui/TableCell (time/ago (time/parse-iso8601 p-updated) @locale)]]
+           (when p-data-gw-url
+             [ui/TableRow {:positive true}
+              [ui/TableCell "Data Gateway Connection"]
+              [ui/TableCell p-data-gw-url]])
+           (when p-data-sample
+             [ui/TableRow {:positive true}
+              [ui/TableCell "Raw Data Sample"]
+              [ui/TableCell p-data-sample]])]
+          (when (> (count actions) 0)
+            [ui/TableFooter
+             [ui/TableRow
+              [ui/TableHeaderCell]
+              [ui/TableHeaderCell
+               [ui/Popup
+                {:position "left center"
+                 :content  "Click to start/stop routing this peripheral's data through the Data Gateway"
+                 :header   "data-gateway"
+                 :inverted true
+                 :wide     "very"
+                 :size     "small"
+                 :trigger  (r/as-element
+                             [ui/Button {:on-click #(do
+                                                      (reset! button-load? true)
+                                                      (dispatch
+                                                        [::events/custom-action p-id (first actions)
+                                                         (str "Triggered " (first actions) " for " p-id)]))
+                                         :floated  "right"
+                                         :color    "vk"
+                                         :size     "large"
+                                         :circular true
+                                         :disabled @button-load?
+                                         :loading  @button-load?}
+                              (first actions)])}]
+               ]]])]
+         :label (or p-name p-product)
+         :title-size :h4
+         :default-open false
+         :icon (case p-interface
+                 "USB" "usb"
+                 nil)]))))
 
 
 (defn Peripherals

--- a/code/src/cljs/sixsq/nuvla/ui/edge_detail/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/edge_detail/views.cljs
@@ -87,7 +87,8 @@
 (defn Peripheral
   [id]
   (let [locale       (subscribe [::i18n-subs/locale])
-        button-load? (r/atom false)
+        last-updated (r/atom {:updated "1970-01-01T00:00:00Z"})
+        button-load? (r/atom true)
         peripheral   (subscribe [::subs/nuvlabox-peripheral id])]
     (fn [id]
       (let [{p-id          :id
@@ -108,93 +109,98 @@
              p-data-gw-url :local-data-gateway-endpoint
              p-data-sample :raw-data-sample} @peripheral
             actions (get-available-actions p-ops)]
-        [uix/Accordion
-         [ui/Table {:basic "very"}
-          [ui/TableBody
-           (when p-product
+        (doall
+          (when (> p-updated (:updated @last-updated))
+            (doall
+              (swap! button-load? not)
+              (swap! last-updated assoc :updated p-updated)))
+          [uix/Accordion
+           [ui/Table {:basic "very"}
+            [ui/TableBody
+             (when p-product
+               [ui/TableRow
+                [ui/TableCell "Name"]
+                [ui/TableCell (str p-name " " p-product)]])
+             (when p-serial-num
+               [ui/TableRow
+                [ui/TableCell "Serial Number"]
+                [ui/TableCell p-serial-num]])
+             (when p-descr
+               [ui/TableRow
+                [ui/TableCell "Description"]
+                [ui/TableCell p-descr]])
              [ui/TableRow
-              [ui/TableCell "Name"]
-              [ui/TableCell (str p-name " " p-product)]])
-           (when p-serial-num
+              [ui/TableCell "Classes"]
+              [ui/TableCell (str/join ", " p-classes)]]
              [ui/TableRow
-              [ui/TableCell "Serial Number"]
-              [ui/TableCell p-serial-num]])
-           (when p-descr
+              [ui/TableCell "Available"]
+              [ui/TableCell
+               [ui/Icon {:name "circle", :color (if p-available "green" "red")}]
+               (if p-available "Yes" "No")]]
+             (when p-interface
+               [ui/TableRow
+                [ui/TableCell "Interface"]
+                [ui/TableCell p-interface]])
+             (when p-device-path
+               [ui/TableRow
+                [ui/TableCell "Device Path"]
+                [ui/TableCell p-device-path]])
+             (when p-video-dev
+               [ui/TableRow
+                [ui/TableCell "Video Device"]
+                [ui/TableCell p-video-dev]])
              [ui/TableRow
-              [ui/TableCell "Description"]
-              [ui/TableCell p-descr]])
-           [ui/TableRow
-            [ui/TableCell "Classes"]
-            [ui/TableCell (str/join ", " p-classes)]]
-           [ui/TableRow
-            [ui/TableCell "Available"]
-            [ui/TableCell
-             [ui/Icon {:name "circle", :color (if p-available "green" "red")}]
-             (if p-available "Yes" "No")]]
-           (when p-interface
+              [ui/TableCell "Identifier"]
+              [ui/TableCell p-identifier]]
              [ui/TableRow
-              [ui/TableCell "Interface"]
-              [ui/TableCell p-interface]])
-           (when p-device-path
+              [ui/TableCell "Vendor"]
+              [ui/TableCell p-vendor]]
              [ui/TableRow
-              [ui/TableCell "Device Path"]
-              [ui/TableCell p-device-path]])
-           (when p-video-dev
+              [ui/TableCell "Created"]
+              [ui/TableCell (time/ago (time/parse-iso8601 p-created) @locale)]]
              [ui/TableRow
-              [ui/TableCell "Video Device"]
-              [ui/TableCell p-video-dev]])
-           [ui/TableRow
-            [ui/TableCell "Identifier"]
-            [ui/TableCell p-identifier]]
-           [ui/TableRow
-            [ui/TableCell "Vendor"]
-            [ui/TableCell p-vendor]]
-           [ui/TableRow
-            [ui/TableCell "Created"]
-            [ui/TableCell (time/ago (time/parse-iso8601 p-created) @locale)]]
-           [ui/TableRow
-            [ui/TableCell "Updated"]
-            [ui/TableCell (time/ago (time/parse-iso8601 p-updated) @locale)]]
-           (when p-data-gw-url
-             [ui/TableRow {:positive true}
-              [ui/TableCell "Data Gateway Connection"]
-              [ui/TableCell p-data-gw-url]])
-           (when p-data-sample
-             [ui/TableRow {:positive true}
-              [ui/TableCell "Raw Data Sample"]
-              [ui/TableCell p-data-sample]])]
-          (when (> (count actions) 0)
-            [ui/TableFooter
-             [ui/TableRow
-              [ui/TableHeaderCell [:span (true? @button-load?)]]
-              [ui/TableHeaderCell
-               [ui/Popup
-                {:position "left center"
-                 :content  "Click to start/stop routing this peripheral's data through the Data Gateway"
-                 :header   "data-gateway"
-                 :inverted true
-                 :wide     "very"
-                 :size     "small"
-                 :trigger  (r/as-element
-                             [ui/Button {:on-click #(do
-                                                      (swap! button-load? not)
-                                                      (dispatch
-                                                        [::events/custom-action p-id (first actions)
-                                                         (str "Triggered " (first actions) " for " p-id)]))
-                                         :floated  "right"
-                                         :color    "vk"
-                                         :size     "large"
-                                         :circular true
-                                         :disabled @button-load?
-                                         :loading  @button-load?}
-                              (first actions)])}]
-               ]]])]
-         :label (or p-name p-product)
-         :title-size :h4
-         :default-open false
-         :icon (case p-interface
-                 "USB" "usb"
-                 nil)]))))
+              [ui/TableCell "Updated"]
+              [ui/TableCell (time/ago (time/parse-iso8601 p-updated) @locale)]]
+             (when p-data-gw-url
+               [ui/TableRow {:positive true}
+                [ui/TableCell "Data Gateway Connection"]
+                [ui/TableCell p-data-gw-url]])
+             (when p-data-sample
+               [ui/TableRow {:positive true}
+                [ui/TableCell "Raw Data Sample"]
+                [ui/TableCell p-data-sample]])]
+            (when (> (count actions) 0)
+              [ui/TableFooter
+               [ui/TableRow
+                [ui/TableHeaderCell]
+                [ui/TableHeaderCell
+                 [ui/Popup
+                  {:position "left center"
+                   :content  "Click to start/stop routing this peripheral's data through the Data Gateway"
+                   :header   "data-gateway"
+                   :inverted true
+                   :wide     "very"
+                   :size     "small"
+                   :trigger  (r/as-element
+                               [ui/Button {:on-click #(do
+                                                        (swap! button-load? not)
+                                                        (dispatch
+                                                          [::events/custom-action p-id (first actions)
+                                                           (str "Triggered " (first actions) " for " p-id)]))
+                                           :floated  "right"
+                                           :color    "vk"
+                                           :size     "large"
+                                           :circular true
+                                           :disabled @button-load?
+                                           :loading  @button-load?}
+                                @last-updated])}]
+                 ]]])]
+           :label (or p-name p-product)
+           :title-size :h4
+           :default-open false
+           :icon (case p-interface
+                   "USB" "usb"
+                   nil)])))))
 
 
 (defn Peripherals

--- a/code/src/cljs/sixsq/nuvla/ui/edge_detail/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/edge_detail/views.cljs
@@ -79,8 +79,15 @@
        :on-refresh #(refresh uuid)}]]))
 
 
+(defn get-available-actions
+  [operations]
+  (filter some? (map #(nth (str/split % #"/") 2 nil) (map :href operations))))
+
+
 (defn Peripheral
-  [{p-name        :name
+  [{p-id          :id
+    p-ops         :operations
+    p-name        :name
     p-product     :product
     p-created     :created
     p-updated     :updated
@@ -90,70 +97,118 @@
     p-available   :available
     p-vendor      :vendor
     p-classes     :classes
-    p-indentifier :identifier}]
-  (let [locale (subscribe [::i18n-subs/locale])]
-    [uix/Accordion
-     [ui/Table {:basic "very"}
-      [ui/TableBody
-       (when p-product
+    p-identifier  :identifier
+    p-serial-num  :serial-number
+    p-video-dev   :video-device
+    p-data-gw-url :local-data-gateway-endpoint
+    p-data-sample :raw-data-sample}]
+  (let [locale  (subscribe [::i18n-subs/locale])
+        actions (get-available-actions p-ops)
+        button-load? (r/atom false)]
+    (fn []
+      [uix/Accordion
+       [ui/Table {:basic "very"}
+        [ui/TableBody
+         (when p-product
+           [ui/TableRow
+            [ui/TableCell "Name"]
+            [ui/TableCell (str p-name " " p-product)]])
+         (when p-serial-num
+           [ui/TableRow
+            [ui/TableCell "Serial Number"]
+            [ui/TableCell p-serial-num]])
+         (when p-descr
+           [ui/TableRow
+            [ui/TableCell "Description"]
+            [ui/TableCell p-descr]])
          [ui/TableRow
-          [ui/TableCell "Name"]
-          [ui/TableCell (str p-name " " p-product)]])
-       (when p-descr
+          [ui/TableCell "Classes"]
+          [ui/TableCell (str/join ", " p-classes)]]
          [ui/TableRow
-          [ui/TableCell "Description"]
-          [ui/TableCell p-descr]])
-       [ui/TableRow
-        [ui/TableCell "Classes"]
-        [ui/TableCell (str/join ", " p-classes)]]
-       [ui/TableRow
-        [ui/TableCell "Available"]
-        [ui/TableCell
-         [ui/Icon {:name "circle", :color (if p-available "green" "red")}]
-         (if p-available "Yes" "No")]]
-       (when p-interface
+          [ui/TableCell "Available"]
+          [ui/TableCell
+           [ui/Icon {:name "circle", :color (if p-available "green" "red")}]
+           (if p-available "Yes" "No")]]
+         (when p-interface
+           [ui/TableRow
+            [ui/TableCell "Interface"]
+            [ui/TableCell p-interface]])
+         (when p-device-path
+           [ui/TableRow
+            [ui/TableCell "Device Path"]
+            [ui/TableCell p-device-path]])
+         (when p-video-dev
+           [ui/TableRow
+            [ui/TableCell "Video Device"]
+            [ui/TableCell p-video-dev]])
          [ui/TableRow
-          [ui/TableCell "Interface"]
-          [ui/TableCell p-interface]])
-       (when p-device-path
+          [ui/TableCell "Identifier"]
+          [ui/TableCell p-identifier]]
          [ui/TableRow
-          [ui/TableCell "Device path"]
-          [ui/TableCell p-device-path]])
-       [ui/TableRow
-        [ui/TableCell "Identifier"]
-        [ui/TableCell p-indentifier]]
-       [ui/TableRow
-        [ui/TableCell "Vendor"]
-        [ui/TableCell p-vendor]]
-       [ui/TableRow
-        [ui/TableCell "Created"]
-        [ui/TableCell (time/ago (time/parse-iso8601 p-created) @locale)]]
-       [ui/TableRow
-        [ui/TableCell "Updated"]
-        [ui/TableCell (time/ago (time/parse-iso8601 p-updated) @locale)]]]
-      ]
-     :label (or p-name p-product)
-     :title-size :h4
-     :default-open false
-     :icon (case p-interface
-             "USB" "usb"
-             nil)]))
+          [ui/TableCell "Vendor"]
+          [ui/TableCell p-vendor]]
+         [ui/TableRow
+          [ui/TableCell "Created"]
+          [ui/TableCell (time/ago (time/parse-iso8601 p-created) @locale)]]
+         [ui/TableRow
+          [ui/TableCell "Updated"]
+          [ui/TableCell (time/ago (time/parse-iso8601 p-updated) @locale)]]
+         (when p-data-gw-url
+           [ui/TableRow {:positive true}
+            [ui/TableCell "Data Gateway Connection"]
+            [ui/TableCell p-data-gw-url]])
+         (when p-data-sample
+           [ui/TableRow {:positive true}
+            [ui/TableCell "Raw Data Sample"]
+            [ui/TableCell p-data-sample]])]
+        (when (> (count actions) 0)
+          [ui/TableFooter
+           [ui/TableRow
+            [ui/TableHeaderCell [:span (true? @button-load?)]]
+            [ui/TableHeaderCell
+             [ui/Popup
+              {:position "left center"
+               :content  "Click to start/stop routing this peripheral's data through the Data Gateway"
+               :header   "data-gateway"
+               :inverted true
+               :wide     "very"
+               :size     "small"
+               :trigger  (r/as-element
+                           [ui/Button {:on-click #(do
+                                                    (swap! button-load? not)
+                                                    (dispatch
+                                                      [::events/custom-action p-id (first actions)
+                                                       (str "Triggered " (first actions) " for " p-id)]))
+                                       :floated "right"
+                                       :color   "vk"
+                                       :size    "large"
+                                       :circular true
+                                       :loading  @button-load?}
+                            (first actions)])}]
+             ]]])]
+       :label (or p-name p-product)
+       :title-size :h4
+       :default-open false
+       :icon (case p-interface
+               "USB" "usb"
+               nil)])))
 
 
 (defn Peripherals
   []
   (let [nuvlabox-peripherals (subscribe [::subs/nuvlabox-peripherals])]
+    (fn []
     [uix/Accordion
      [:div
       (doall
-        (for [{p-indentifier :identifier
-               p-created     :created
+        (for [{p-identifier  :identifier
+               p-updated     :updated
                :as           peripheral} @nuvlabox-peripherals]
-          ^{:key (str p-indentifier p-created)}
+          ^{:key (str p-identifier p-updated)}
           [Peripheral peripheral]))]
      :label "Peripherals"
      :icon "usb"
-     :count (count @nuvlabox-peripherals)]))
+     :count (count @nuvlabox-peripherals)])))
 
 
 (defn LocationAccordion


### PR DESCRIPTION
@0xbase12 atm, the peripheral accordions are re-rendered whenever there's an update to any peripheral. This means the order of the accordions will change and the collapsing will be reset to false

Is there a way to subscribe to each peripheral, instead of all of them, so that if there's a change to a single peripheral resource, the only thing that is re-rendered is the corresponding table inside the respective accordion?

fixes #283 