### PR TITLE
checkbox label with Rancher or Portainer as COE manager in IS install

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/infrastructures/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/infrastructures/views.cljs
@@ -295,8 +295,11 @@
                                      (on-change :multiplicity @multiplicity)))
                      :step        1
                      :min         1}]]
+
          [ui/Checkbox {:key             "coe-manager-install"
-                       :label           (@tr [:coe-install-manager-portainer])
+                       :label           (if (= subtype "swarm")
+                                          (@tr [:coe-install-manager-portainer])
+                                          (@tr [:coe-install-manager-rancher]))
                        :disabled        (not @mgmt-cred-set?)
                        :default-checked false
                        :style           {:margin "1em"}


### PR DESCRIPTION
Displays the corresponding message with Rancher or Portainer depending if the user selected K8s or Swarm to be provisioned.
To be merged with https://github.com/nuvla/job-engine/pull/112 (which provides implementation of installation of Rancher)