### PR TITLE
Launch dialog: fixed an issue where the launch dialog will not show the Registries step ...

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/deployment_dialog/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/deployment_dialog/events.cljs
@@ -129,9 +129,9 @@
                                    registry-ids
                                    (map-indexed
                                      (fn [n reg-id]
-                                       (let [cred-id (-> (nth reg-creds-ids n)
-                                                         str/trim
-                                                         not-empty)]
+                                       (let [cred-id (some-> (nth reg-creds-ids n)
+                                                             str/trim
+                                                             not-empty)]
                                          [reg-id
                                           {:cred-id      cred-id
                                            :preselected? (some? cred-id)}])))


### PR DESCRIPTION
… if the module contain a private registry and is older than the introduction of the marketplace.