### PR TITLE
Fix logo size on cards

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/utils/semantic_ui_extensions.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/utils/semantic_ui_extensions.cljs
@@ -380,7 +380,7 @@
        :bordered true
        :style    {:width      "auto"
                   :height     "200px"
-                  :object-fit "cover"}}])
+                  :object-fit "scale-down"}}])
 
    (when corner-button corner-button)
 


### PR DESCRIPTION
This ensure that the logo is fully contained (with no distortions) in his dedicated area.
`scale-down` is like `contain` but doesn't scale up if the logo is smaller than its area.