### PR TITLE
Preview deployments on Cloudflare Pages

### DIFF
--- a/.github/workflows/prev_deploy.yml
+++ b/.github/workflows/prev_deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+  pull_request:
+    types: [opened]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Allow GITHUB_TOKEN to write deployments for my action (https://docs.github.com/en/actions/security-guides/automatic-token-authentication)
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+    steps:
+      - name: Await CF Pages
+        uses: WalshyDev/cf-pages-await@v1
+        id: pages-action
+        with:
+          # Use an API token (Recommended!)
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+
+          accountId: '9793bc27d30f5d738baf5e5a491b7416'
+          project: 'nuvla-ui'
+          # Add this if you want GitHub Deployments (see below)
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          # Add this if you want to wait for a deployment triggered by a specfied commit
+          commitHash: ${{ steps.push-changes.outputs.commit-hash }}
+
+      - name: Comment on GitHub
+        uses: daohoangson/comment-on-github@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          body: 'URL for specific commit: ${{ steps.pages-action.outputs.url }}, URL for branch alias: ${{ steps.pages-action.outputs.alias }}  (${{ steps.pages-action.outputs.environment }})'

--- a/code/functions/api/[[path]].js
+++ b/code/functions/api/[[path]].js
@@ -1,0 +1,34 @@
+export async function onRequest(context) {
+  // Contents of context object
+  let {
+    request, // same as existing Worker API                           -> needed
+    env, // same as existing Worker API                               -> needed for different api backends than nuvla.io
+    params, // if filename includes [id] or [[path]]
+    waitUntil, // same as ctx.waitUntil in existing Worker API
+    next, // used for middleware or to fetch assets
+    data, // arbitrary space for passing data between middlewares
+  } = context;
+  const projectNameOnCFPages = 'nuvla-ui';
+  const url = new URL(request.url);
+
+  const firstPartOfHost = url.host.split('.')[0];
+
+  const procutionApiEndpoint = 'https://nuvla.io';
+
+  // try get api endpoint from environment or staging for preview depoyments, if present
+  let apiUrl =
+    firstPartOfHost === projectNameOnCFPages
+      ? procutionApiEndpoint
+      : env[firstPartOfHost] || env['staging'] || 'https://nuvla.io';
+
+  let response = await fetch(apiUrl + url.pathname, request);
+
+  // override base-uri for /api/cloud-entry-point responses
+  if (url.pathname.includes('cloud-entry-point')) {
+    let body = await response.json();
+    body = { ...body, 'base-uri': url.origin + '/api/' };
+    return new Response(JSON.stringify(body));
+  }
+
+  return response;
+}

--- a/code/functions/proxy/[[path]].js
+++ b/code/functions/proxy/[[path]].js
@@ -1,0 +1,15 @@
+export async function onRequest(context) {
+  // Contents of context object
+  let {
+    request, // same as existing Worker API
+    env, // same as existing Worker API
+    params, // if filename includes [id] or [[path]]
+    waitUntil, // same as ctx.waitUntil in existing Worker API
+    next, // used for middleware or to fetch assets
+    data, // arbitrary space for passing data between middlewares
+  } = context;
+  const url = new URL(request.url);
+  let productionEndpoint = 'https://nuvla.io';
+
+  return fetch(`${productionEndpoint}${url.pathname.replace('/proxy/', '/')}`);
+}

--- a/code/resources/public/index.html
+++ b/code/resources/public/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="Description" content="Web application for Nuvla, a cloud and edge application management platform." />
+
+    <title>Nuvla&reg;</title>
+
+    <!-- These are not part of the ui repo: add additional first path segment /proxy/
+      to make for reverse proxying simpler -->
+    <link rel="stylesheet" href="/proxy/ui/css/semantic.min.css" />
+    <link rel="stylesheet" href="/proxy/ui/css/version.css" />
+    <link rel="icon" href="/proxy/ui/images/favicon.ico" type="image/x-icon" />
+    <link rel="stylesheet" href="/proxy/ui/css/react-datepicker.min.css" />
+    <link rel="stylesheet" href="/proxy/ui/css/codemirror.css" />
+    <link rel="stylesheet" href="/proxy/ui/css/foldgutter.css" />
+    <link rel="stylesheet" href="/proxy/ui/css/dialog.css" />
+    <link rel="stylesheet" href="/proxy/ui/css/matchesonscrollbar.css" />
+    <link rel="stylesheet" href="/proxy/ui/css/leaflet.css" />
+    <link rel="stylesheet" href="/proxy/ui/css/leaflet.draw.css" />
+
+    <!-- These are part of ui repo: no reverse proxy -->
+    <link rel="stylesheet" href="/ui/css/nuvla-ui.css" />
+    <link rel="stylesheet" href="/ui/css/all.min.css" />
+  </head>
+
+  <body>
+    <noscript>
+      <p>The Nuvla browser interface requires JavaScript. Please enable this in your browser.</p>
+    </noscript>
+    <div id="app"></div>
+    <script src="/ui/js/nuvla-ui.js"></script>
+    <script>
+      sixsq.nuvla.ui.core.init();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
These are the changes needed to get automatic preview deployments on Cloudflare Pages on pushes to all branches and PRs.

1. `functions` folder: These provide reverse proxies (automatically deployed as Cloudflare Workers) to our Api and some assets that are not checked into the repository. They run on their respective folder paths `/api/*` and `/proxy/css/*`
2. `index.html` duplicated one folder up in `public` to correctly load assets from paths starting with `/ui/...`. Additionally changed paths to assets outside repository to start with `/proxy/` to simplify the asset reverse proxy.
3. Deploy preview Github Action workflow pipeline file (only needed for commenting on Github).

Services needed from Cloudflare:
1. Cloudflare Pages (free: 500 builds per month)
2. Cloudflare Workers for reverse proxy (free: 100'000 requests per day)
3. Cloudflare Zero Trust/Access if we want to protect the deployed previews (free: up to 50 users)

This would give us simpler and faster feedback on UI changes.

Default Api endpoint ist production server, can be configured in env variables on Cloudflare for every branch and/or staging.