### PR TITLE
Issue 1155: Fixes to changes protection modal

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/apps/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/apps/events.cljs
@@ -7,6 +7,7 @@
             [sixsq.nuvla.ui.apps-component.utils :as apps-component-utils]
             [sixsq.nuvla.ui.apps-project.spec :as apps-project-spec]
             [sixsq.nuvla.ui.apps-project.utils :as apps-project-utils]
+            [sixsq.nuvla.ui.apps-store.spec :as apps-store-spec]
             [sixsq.nuvla.ui.apps.effects :as apps-fx]
             [sixsq.nuvla.ui.apps.spec :as spec]
             [sixsq.nuvla.ui.apps.utils :as utils]
@@ -617,9 +618,9 @@
                                (dispatch [::set-module sanitized-module]) ;Needed?
                                (when (= subtype "application")
                                  (dispatch [::validate-docker-compose (:resource-id %)]))
-                               (dispatch [::main-events/changes-protection? false])
-                               (dispatch [::routing-events/navigate
-                                          (str-pathify (name->href routes/apps) (:path sanitized-module))]))
+                               (dispatch [::main-events/reset-changes-protection
+                                          [::routing-events/navigate
+                                           (str-pathify (name->href routes/apps) (:path sanitized-module))]]))
                             :on-error #(let [{:keys [status]} (response/parse-ex-info %)]
                                          (cimi-api-fx/default-add-on-error :module %)
                                          (when (= status 409)
@@ -638,18 +639,18 @@
                                 (do (dispatch [::get-module (version-id->index %)])
                                     (when (= subtype "application")
                                       (dispatch [::validate-docker-compose %]))
-                                    (dispatch [::main-events/changes-protection? false])))]}))))
+                                    (dispatch [::main-events/reset-changes-protection])))]}))))
 
 
 (reg-event-fx
   ::delete-module
   (fn [{:keys [db]} [_ id]]
-    {:db                  (-> db
-                              (dissoc ::spec/module)
-                              (assoc ::spec/form-valid? true))
-     ::cimi-api-fx/delete [id #(do
-                                 (dispatch [::main-events/changes-protection? false])
-                                 (dispatch [::routing-events/navigate routes/apps]))]}))
+    ;; TODO: Add on-error restoring changes-protection
+    (let [query-params {:apps-store-tab (-> db ::apps-store-spec/tab :default-tab)}]
+      {:db                  (-> db
+                                (dissoc ::spec/module)
+                                (assoc  ::spec/form-valid? true))
+       ::cimi-api-fx/delete [id #(dispatch [::routing-events/navigate routes/apps nil query-params])]})))
 
 
 (reg-event-db
@@ -680,10 +681,9 @@
                                 (assoc :path (utils/contruct-path paste-parent-path new-module-name)))]
 
       {::cimi-api-fx/add [:module paste-module
-                          #(do
-                             (dispatch [::main-events/changes-protection? false])
-                             (dispatch [::routing-events/navigate
-                                        (str-pathify (name->href routes/apps) (:path paste-module))]))
+                          #(dispatch [::main-events/reset-changes-protection
+                                      [::routing-events/navigate
+                                       (str-pathify (name->href routes/apps) (:path paste-module))]])
                           :on-error #(let [{:keys [status]} (response/parse-ex-info %)]
                                        (cimi-api-fx/default-add-on-error :module %)
                                        (when (= status 409)

--- a/code/src/cljs/sixsq/nuvla/ui/apps/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/apps/events.cljs
@@ -650,7 +650,8 @@
       {:db                  (-> db
                                 (dissoc ::spec/module)
                                 (assoc  ::spec/form-valid? true))
-       ::cimi-api-fx/delete [id #(dispatch [::routing-events/navigate routes/apps nil query-params])]})))
+       ::cimi-api-fx/delete [id #(dispatch [::main-events/reset-changes-protection
+                                            [::routing-events/navigate routes/apps nil query-params]])]})))
 
 
 (reg-event-db

--- a/code/src/cljs/sixsq/nuvla/ui/apps/views_detail.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/apps/views_detail.cljs
@@ -123,7 +123,8 @@
         {:keys [id name description]} module
         content (str (or name id) (when description " - ") (utils-values/markdown->summary description))]
     [uix/ModalDanger
-     {:on-confirm  #(dispatch [::events/delete-module id])
+     {:on-confirm   #(do (dispatch [::main-events/reset-changes-protection])
+                        (dispatch [::events/delete-module id]))
       :trigger     (r/as-element [ui/MenuItem {:disabled @is-new?}
                                   [ui/Icon {:name "trash"}]
                                   (str/capitalize (@tr [:delete]))])

--- a/code/src/cljs/sixsq/nuvla/ui/apps/views_detail.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/apps/views_detail.cljs
@@ -123,8 +123,7 @@
         {:keys [id name description]} module
         content (str (or name id) (when description " - ") (utils-values/markdown->summary description))]
     [uix/ModalDanger
-     {:on-confirm   #(do (dispatch [::main-events/reset-changes-protection])
-                        (dispatch [::events/delete-module id]))
+     {:on-confirm   (fn [] (dispatch [::events/delete-module id]))
       :trigger     (r/as-element [ui/MenuItem {:disabled @is-new?}
                                   [ui/Icon {:name "trash"}]
                                   (str/capitalize (@tr [:delete]))])

--- a/code/src/cljs/sixsq/nuvla/ui/apps_store/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/apps_store/events.cljs
@@ -18,6 +18,11 @@
           [:dispatch [::apps-events/module-not-found false]]]}))
 
 (reg-event-db
+  ::set-default-tab
+  (fn [db [_ active-tab]]
+    (update db ::spec/tab assoc :default-tab active-tab)))
+
+(reg-event-db
   ::set-modules
   (fn [db [_ modules]]
     (assoc db ::spec/modules modules

--- a/code/src/cljs/sixsq/nuvla/ui/apps_store/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/apps_store/views.cljs
@@ -126,6 +126,7 @@
 (defn TabDefault
   [active-tab]
   (dispatch [::events/get-modules active-tab])
+  (dispatch [::events/set-default-tab active-tab])
   ^{:key active-tab}
   [components/LoadingPage {}
    [ui/TabPane

--- a/code/src/cljs/sixsq/nuvla/ui/edges_detail/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/edges_detail/views.cljs
@@ -1459,7 +1459,7 @@
                          :on-drag-end (map/drag-end-location update-new-location)}])]
          [:div {:align "right"}
           [ui/Button {:on-click #(do (reset! new-location nil)
-                                     (dispatch [::main-events/changes-protection? false]))}
+                                     (dispatch [::main-events/reset-changes-protection]))}
            (@tr [:cancel])]
           [ui/Button {:primary  true
                       :on-click #(do (dispatch
@@ -1468,7 +1468,7 @@
                                           :location
                                           (update @new-location 0 map/normalize-lng))
                                         (@tr [:nuvlabox-position-update])])
-                                     (dispatch [::main-events/changes-protection? false]))
+                                     (dispatch [::main-events/reset-changes-protection]))
                       :disabled (nil? @new-location)}
            (@tr [:save])]]]))))
 

--- a/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
@@ -41,3 +41,39 @@
     (if protected?
       (set-unload-protection)
       (clear-unload-protection))))
+
+(comment
+  (set-unload-protection)
+  (clear-unload-protection)
+  )
+
+(defn- stop-browser-back
+  [f]
+  (.pushState js/window.history nil "" (.-href js/window.location))
+  (set!
+    js/window.onpopstate
+    (fn []
+      (.pushState js/window.history nil "" (.-href js/window.location))
+      (when (fn? f) (f)))))
+
+(defn- start-browser-back
+  []
+  (set! js/window.onpopstate nil)
+  (.back js/window.history))
+
+(comment
+  (stop-browser-back +)
+  (start-browser-back)
+  )
+
+(reg-fx
+  ::disable-browser-back
+  (fn [f]
+    (js/console.error "disable-browser-back")
+    (stop-browser-back f)))
+
+(reg-fx
+  ::enable-browser-back
+  (fn [_]
+    (js/console.error "enable-browser-back effect")
+    (start-browser-back)))

--- a/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
@@ -38,7 +38,6 @@
 (reg-fx
   ::on-unload-protection
   (fn [protected?]
-(js/console.error "::on-unload-protection")
     (if protected?
       (set-unload-protection)
       (clear-unload-protection))))
@@ -70,20 +69,17 @@
 (reg-fx
   ::disable-browser-back
   (fn [f]
-    (js/console.error "disable-browser-back")
     (stop-browser-back f)))
 
 
 (reg-fx
   ::add-pop-state-listener-close-modal-event
   (fn [f]
-    (.addEventListener js/window "popstate" f)
-    (js/console.error "add-pop-state-listener-close-modal-event")))
+    (.addEventListener js/window "popstate" f)))
 
 (reg-fx
   ::enable-browser-back
   (fn [fn]
-    (js/console.error "enable-browser-back effect" fn)
     (start-browser-back)
     (when (fn? fn) (fn))))
 
@@ -91,6 +87,5 @@
   ::clear-popstate-event-listener
   (fn
     [f]
-    (js/console.error "::clear-popstate-event-listener")
-    (.removeEventListener js/window "popstate" f)
-    ))
+    (js/console.error "clear-popstate-event-listener")
+    (.removeEventListener js/window "popstate" f)))

--- a/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
@@ -75,6 +75,7 @@
 
 (reg-fx
   ::enable-browser-back
-  (fn [_]
-    (js/console.error "enable-browser-back effect")
-    (start-browser-back)))
+  (fn [fn]
+    (js/console.error "enable-browser-back effect" fn)
+    (start-browser-back)
+    (when (fn? fn) (fn))))

--- a/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
@@ -73,6 +73,19 @@
     (js/console.error "disable-browser-back")
     (stop-browser-back f)))
 
+
+
+(defn- add-popstate-event-listener
+  [f]
+    (js/console.error "add-popstate-event-listener" f)
+  (.addEventListener js/window "popstate" f))
+
+(reg-fx
+  ::add-pop-state-listener-close-modal-event
+  (fn [f]
+    (add-popstate-event-listener f)
+    (js/console.error "disable-browser-back")))
+
 (reg-fx
   ::enable-browser-back
   (fn [fn]

--- a/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
@@ -74,17 +74,11 @@
     (stop-browser-back f)))
 
 
-
-(defn- add-popstate-event-listener
-  [f]
-    (js/console.error "add-popstate-event-listener" f)
-  (.addEventListener js/window "popstate" f))
-
 (reg-fx
   ::add-pop-state-listener-close-modal-event
   (fn [f]
-    (add-popstate-event-listener f)
-    (js/console.error "disable-browser-back")))
+    (.addEventListener js/window "popstate" f)
+    (js/console.error "add-pop-state-listener-close-modal-event")))
 
 (reg-fx
   ::enable-browser-back
@@ -92,3 +86,11 @@
     (js/console.error "enable-browser-back effect" fn)
     (start-browser-back)
     (when (fn? fn) (fn))))
+
+(reg-fx
+  ::clear-popstate-event-listener
+  (fn
+    [f]
+    (js/console.error "::clear-popstate-event-listener")
+    (.removeEventListener js/window "popstate" f)
+    ))

--- a/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
@@ -62,8 +62,6 @@
   [f nav-back?]
   (set! js/window.onpopstate nil)
   ;; if modal was opened by navigating back, go back two steps in history stack
-(js/console.error "start-browser-back f" f)
-(js/console.error "start-browser-back nav-back?" f)
   (cond
     nav-back? (.go js/window.history -2)
     (fn? f)   (f)
@@ -79,7 +77,6 @@
 (reg-fx
   ::enable-browser-back
   (fn [{:keys [cb-fn nav-back?]}]
-    (js/console.error "::enable-browser-back fx")
     (start-browser-back cb-fn nav-back?)))
 
 (reg-fx

--- a/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
@@ -38,6 +38,7 @@
 (reg-fx
   ::on-unload-protection
   (fn [protected?]
+(js/console.error "::on-unload-protection")
     (if protected?
       (set-unload-protection)
       (clear-unload-protection))))

--- a/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
@@ -38,6 +38,7 @@
 (reg-fx
   ::on-unload-protection
   (fn [protected?]
+    (js/console.error "2: ::on-unload-protection")
     (if protected?
       (set-unload-protection)
       (clear-unload-protection))))
@@ -58,8 +59,10 @@
 
 (defn- start-browser-back
   []
+  (js/console.error "4a: start-browser-back before setting onpopstate nil")
   (set! js/window.onpopstate nil)
-  (.back js/window.history))
+  (js/console.error "4b: start-browser-back before browser back")
+  (.back js/window.history)  (js/console.error "4c: start-browser-back after browser back"))
 
 (comment
   (stop-browser-back +)
@@ -73,19 +76,21 @@
 
 
 (reg-fx
+  ::enable-browser-back
+  (fn [fn]
+    (js/console.error "3: ::fx/enable-browser-back")
+    (start-browser-back)
+    (when (fn? fn) (fn))))
+
+(reg-fx
   ::add-pop-state-listener-close-modal-event
   (fn [f]
     (.addEventListener js/window "popstate" f)))
 
-(reg-fx
-  ::enable-browser-back
-  (fn [fn]
-    (start-browser-back)
-    (when (fn? fn) (fn))))
 
 (reg-fx
   ::clear-popstate-event-listener
   (fn
     [f]
-    (js/console.error "clear-popstate-event-listener")
+    (js/console.error "1: clear-popstate-event-listener")
     (.removeEventListener js/window "popstate" f)))

--- a/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
@@ -62,8 +62,12 @@
   [f nav-back?]
   (set! js/window.onpopstate nil)
   ;; if modal was opened by navigating back, go back two steps in history stack
-  (if nav-back? (.go js/window.history -2)
-    (if (fn? f) (f) (.back js/window.history))))
+(js/console.error "start-browser-back f" f)
+(js/console.error "start-browser-back nav-back?" f)
+  (cond
+    nav-back? (.go js/window.history -2)
+    (fn? f)   (f)
+    :else     (.back js/window.history)))
 
 
 (reg-fx
@@ -75,6 +79,7 @@
 (reg-fx
   ::enable-browser-back
   (fn [{:keys [cb-fn nav-back?]}]
+    (js/console.error "::enable-browser-back fx")
     (start-browser-back cb-fn nav-back?)))
 
 (reg-fx

--- a/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
@@ -42,10 +42,6 @@
       (set-unload-protection)
       (clear-unload-protection))))
 
-(comment
-  (set-unload-protection)
-  (clear-unload-protection)
-  )
 
 (defn- stop-browser-back
   "It's not possible to disable navigate back in modern browsers.
@@ -69,9 +65,6 @@
   (if nav-back? (.go js/window.history -2)
     (if (fn? f) (f) (.back js/window.history))))
 
-(comment
-  (stop-browser-back +)
-  (start-browser-back + -))
 
 (reg-fx
   ::disable-browser-back

--- a/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/effects.cljs
@@ -38,7 +38,6 @@
 (reg-fx
   ::on-unload-protection
   (fn [protected?]
-    (js/console.error "2: ::on-unload-protection")
     (if protected?
       (set-unload-protection)
       (clear-unload-protection))))
@@ -58,15 +57,13 @@
       (when (fn? f) (f)))))
 
 (defn- start-browser-back
-  []
-  (js/console.error "4a: start-browser-back before setting onpopstate nil")
+  [f]
   (set! js/window.onpopstate nil)
-  (js/console.error "4b: start-browser-back before browser back")
-  (.back js/window.history)  (js/console.error "4c: start-browser-back after browser back"))
+  (if (fn? f) (f) (.back js/window.history)))
 
 (comment
   (stop-browser-back +)
-  (start-browser-back)
+  (start-browser-back +)
   )
 
 (reg-fx
@@ -77,10 +74,8 @@
 
 (reg-fx
   ::enable-browser-back
-  (fn [fn]
-    (js/console.error "3: ::fx/enable-browser-back")
-    (start-browser-back)
-    (when (fn? fn) (fn))))
+  (fn [f]
+    (start-browser-back f)))
 
 (reg-fx
   ::add-pop-state-listener-close-modal-event
@@ -92,5 +87,4 @@
   ::clear-popstate-event-listener
   (fn
     [f]
-    (js/console.error "1: clear-popstate-event-listener")
     (.removeEventListener js/window "popstate" f)))

--- a/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
@@ -137,20 +137,12 @@
 
 (reg-event-fx
   ::reset-changes-protection
-  (fn [{db :db} [_ after-clear-event]]
-    (js/console.error ::reset-changes-protection after-clear-event)
-    (let [protected? (get db ::spec/changes-protection?)]
-      (if protected?
-      (do
-        (js/console.error "::reset-changes-protection protected" protected?)
-        {:db (assoc db
-               ::spec/changes-protection? false
-               ::routing-events/ignore-changes-protection true
-              ;;  ::spec/after-clear-event {:fx [(when after-clear-event [:dispatch after-clear-event])]}
-               )
-         :fx [[::fx/on-unload-protection false]
-              [:dispatch [::enable-browser-back {:cb-fn #(dispatch [::after-clear-event after-clear-event])}]]]})
-        {:fx [(when after-clear-event [:dispatch after-clear-event])]}))))
+  (fn [{{protected? ::spec/changes-protection? :as db} :db} [_ after-clear-event]]
+    (if protected?
+      {:db (assoc db ::spec/changes-protection? false)
+       :fx [[::fx/on-unload-protection false]
+            [::fx/enable-browser-back (when after-clear-event {:cb-fn (fn [] (dispatch after-clear-event))})]]}
+      {:fx [(when after-clear-event [:dispatch after-clear-event])]})))
 
 (reg-event-fx
   ::changes-protection?
@@ -237,11 +229,8 @@
 
 (reg-event-fx
   ::enable-browser-back
-  (fn [{db :db} [_ payload]]
-    (js/console.error "::enable-browser-back event, payload" payload)
-    (js/console.error "::enable-browser-back event, changes-protection?" (::spec/changes-protection? db))
-    {:db (assoc db ::routing-events/ignore-changes-protection true)
-     :fx [[::fx/enable-browser-back payload]]}))
+  (fn [_ [_ payload]]
+    {:fx [[::fx/enable-browser-back payload]]}))
 
 
 

--- a/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
@@ -173,20 +173,20 @@
   (fn [_ _]
     {:fx [[::fx/disable-browser-back]]}))
 
-(reg-event-fx
-  ::close-modal-by-back-button
-  (fn [{db :db} _]
-(js/console.error "::close-modal-by-back-button")
-    {:db (assoc db ::spec/ignore-changes-modal nil
-                                   ::spec/do-not-ignore-changes-modal nil)
-     :fx [[::ignore-changes false]]}))
-
 (defn- dispatch-close-modal-by-back-button-event
   []
   (js/console.error "dispatch-close-modal-by-back-button-event")
   (dispatch [::close-modal-by-back-button])
-  ;; TODO: Dispatch event->effect to remove event-listener
   )
+
+(reg-event-fx
+  ::close-modal-by-back-button
+  (fn [{db :db} _]
+    {:db (assoc db ::spec/ignore-changes-modal nil
+                   ::spec/do-not-ignore-changes-modal nil)
+     :fx [[::ignore-changes false]
+          [::fx/clear-popstate-event-listener dispatch-close-modal-by-back-button-event]]}))
+
 
 (reg-event-fx
   ::opening-protection-modal

--- a/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
@@ -132,7 +132,6 @@
 (reg-event-fx
   ::changes-protection?
   (fn [{db :db} [_ protect?]]
-    (js/console.error "changes-protection?" protect?)
     (let [protected? (get db ::spec/changes-protection?)
           changed?   (not= protect? protected?)]
       (when changed?
@@ -142,9 +141,7 @@
 
 (defn- dispatch-close-modal-by-back-button-event
   []
-(js/console.error "dispatch-close-modal-by-back-button-event")
-  (dispatch [::close-modal-by-back-button])
-  )
+  (dispatch [::close-modal-by-back-button]))
 
 (reg-event-fx
   ::clear-changes-protections
@@ -162,21 +159,22 @@
                                    ::spec/do-not-ignore-changes-modal nil)]
       (if choice
         (let [new-db (-> close-modal-db
-                       (assoc ::spec/after-clear-event ignore-changes-modal)
-                       (assoc ::spec/changes-protection? false))]
+                         (assoc ::spec/after-clear-event ignore-changes-modal)
+                         (assoc ::spec/changes-protection? false))]
           (cond
             (map? ignore-changes-modal)
-            (do (js/console.error "ignore-changes-modal" ignore-changes-modal)
-              {:db new-db
-               :fx [[:dispatch [::clear-changes-protections]]]})
+            {:db new-db
+             :fx [[:dispatch [::clear-changes-protections]]]}
 
             (fn? ignore-changes-modal)
             (do (ignore-changes-modal)
               {:db new-db
                :fx [[:dispatch [::clear-changes-protections]]]})))
 
-        (merge {:db close-modal-db}
-          do-not-ignore-changes-modal)))))
+        (merge  {:db close-modal-db} do-not-ignore-changes-modal
+          #_(update do-not-ignore-changes-modal
+              :fx conj
+              [::fx/clear-popstate-event-listener dispatch-close-modal-by-back-button-event]))))))
 
 (reg-event-fx
   ::disable-browser-back
@@ -188,8 +186,7 @@
   (fn [{db :db} _]
     {:db (assoc db ::spec/ignore-changes-modal nil
                    ::spec/do-not-ignore-changes-modal nil)
-     :fx [[::ignore-changes false]
-          [::fx/clear-popstate-event-listener dispatch-close-modal-by-back-button-event]]}))
+     :fx [[::fx/clear-popstate-event-listener dispatch-close-modal-by-back-button-event]]}))
 
 
 (reg-event-fx
@@ -197,10 +194,6 @@
   (fn [_ _]
     {:fx [[::fx/add-pop-state-listener-close-modal-event dispatch-close-modal-by-back-button-event]]}))
 
-;; (defn- dispatch-after-clear-effect
-;;   []
-;;   (js/console.error "dispatch-after-clear-effect")
-;;   (dispatch [::after-clear-event]))
 
 (reg-event-fx
   ::enable-browser-back
@@ -211,7 +204,6 @@
 (reg-event-fx
   ::after-clear-event
   (fn [{{after-clear-event ::spec/after-clear-event :as db} :db}]
-    (js/console.error "after-clear-event" after-clear-event)
     {:db (assoc db ::spec/after-clear-event nil)
      :fx (:fx after-clear-event)}))
 

--- a/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
@@ -132,7 +132,6 @@
 (reg-event-fx
   ::changes-protection?
   (fn [{db :db} [_ protect?]]
-    (js/console.error "changes-protection?" protect?)
     (let [protected? (get db ::spec/changes-protection?)
           changed?   (not= protect? protected?)]
       (when changed?
@@ -143,14 +142,18 @@
 (reg-event-fx
   ::clear-change-protections
   (fn [_ [_ effect]]
-(js/console.error "clear-change-protections" effect)
     {:fx [[:dispatch [::changes-protection? false effect]]]}))
+
+(defn- dispatch-close-modal-by-back-button-event
+  []
+(js/console.error "dispatch-close-modal-by-back-button-event")
+  (dispatch [::close-modal-by-back-button])
+  )
 
 (reg-event-fx
   ::ignore-changes
   (fn [{{:keys [::spec/ignore-changes-modal
                 ::spec/do-not-ignore-changes-modal] :as db} :db} [_ choice]]
-    (js/console.error "::ignore-changes" choice)
     (let [close-modal-db (assoc db ::spec/ignore-changes-modal nil
                                    ::spec/do-not-ignore-changes-modal nil)]
       (if choice
@@ -173,11 +176,6 @@
   (fn [_ _]
     {:fx [[::fx/disable-browser-back]]}))
 
-(defn- dispatch-close-modal-by-back-button-event
-  []
-  (js/console.error "dispatch-close-modal-by-back-button-event")
-  (dispatch [::close-modal-by-back-button])
-  )
 
 (reg-event-fx
   ::close-modal-by-back-button
@@ -191,32 +189,27 @@
 (reg-event-fx
   ::opening-protection-modal
   (fn [_ _]
-    (js/console.error "::opening-protection-modal")
     {:fx [[::fx/add-pop-state-listener-close-modal-event dispatch-close-modal-by-back-button-event]]}))
 
 (defn- dispatch-after-clear-effect
   []
-  (js/console.error "dispatch-after-clear-effect")
   (dispatch [::after-clear-event]))
 
 (reg-event-fx
   ::enable-browser-back
   (fn [{db :db}]
-    (js/console.error "enable-ignore-modal")
     {:db (assoc db ::routing-events/ignore-changes-protection true)
      :fx [[::fx/enable-browser-back dispatch-after-clear-effect]]}))
 
 (reg-event-fx
   ::after-clear-event
   (fn [{{after-clear-event ::spec/after-clear-event} :db}]
-(js/console.error ::after-clear-event after-clear-event)
     after-clear-event))
 
 
 (reg-event-fx
   ::close-ignore-modal
   (fn [{db :db} _]
-    (js/console.error "close-ignore-modal")
     {:db (assoc db ::spec/ignore-changes-modal nil
            ::spec/do-not-ignore-changes-modal nil)}))
 

--- a/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
@@ -195,7 +195,6 @@
 (reg-event-fx
   ::after-clear-event
   (fn [{{after-clear-event ::spec/after-clear-event :as db} :db}]
-    (js/console.error "::after-clear-event" after-clear-event)
     {:db (assoc db ::spec/after-clear-event nil)
      :fx (:fx after-clear-event)}))
 

--- a/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
@@ -150,6 +150,7 @@
   ::ignore-changes
   (fn [{{:keys [::spec/ignore-changes-modal
                 ::spec/do-not-ignore-changes-modal] :as db} :db} [_ choice]]
+    (js/console.error "::ignore-changes" choice)
     (let [close-modal-db (assoc db ::spec/ignore-changes-modal nil
                                    ::spec/do-not-ignore-changes-modal nil)]
       (if choice
@@ -172,7 +173,28 @@
   (fn [_ _]
     {:fx [[::fx/disable-browser-back]]}))
 
-(defn dispatch-after-clear-effect
+(reg-event-fx
+  ::close-modal-by-back-button
+  (fn [{db :db} _]
+(js/console.error "::close-modal-by-back-button")
+    {:db (assoc db ::spec/ignore-changes-modal nil
+                                   ::spec/do-not-ignore-changes-modal nil)
+     :fx [[::ignore-changes false]]}))
+
+(defn- dispatch-close-modal-by-back-button-event
+  []
+  (js/console.error "dispatch-close-modal-by-back-button-event")
+  (dispatch [::close-modal-by-back-button])
+  ;; TODO: Dispatch event->effect to remove event-listener
+  )
+
+(reg-event-fx
+  ::opening-protection-modal
+  (fn [_ _]
+    (js/console.error "::opening-protection-modal")
+    {:fx [[::fx/add-pop-state-listener-close-modal-event dispatch-close-modal-by-back-button-event]]}))
+
+(defn- dispatch-after-clear-effect
   []
   (js/console.error "dispatch-after-clear-effect")
   (dispatch [::after-clear-event]))

--- a/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
@@ -131,14 +131,14 @@
 
 (reg-event-fx
   ::changes-protection?
-  (fn [{db :db} [_ protect? effect]]
-    (js/console.error "changes-protection?" protect? effect)
+  (fn [{db :db} [_ protect?]]
+    (js/console.error "changes-protection?" protect?)
     (let [protected? (get db ::spec/changes-protection?)
           changed?   (not= protect? protected?)]
       (when changed?
         {:db (assoc db ::spec/changes-protection? protect?)
          :fx [[::fx/on-unload-protection protect?]
-              [:dispatch (if protect? [::disable-browser-back] [::enable-browser-back effect])]]}))))
+              [:dispatch (if protect? [::disable-browser-back] [::enable-browser-back])]]}))))
 
 (reg-event-fx
   ::clear-change-protections
@@ -156,8 +156,8 @@
         (cond
           (map? ignore-changes-modal)
           (do (js/console.error "ignore-changes-modal" ignore-changes-modal)
-            {:db close-modal-db
-             :fx [[:dispatch [::clear-change-protections ignore-changes-modal]]]})
+            {:db (assoc close-modal-db ::spec/after-clear-event ignore-changes-modal)
+             :fx [[:dispatch [::clear-change-protections]]]})
 
           (fn? ignore-changes-modal)
           (do (ignore-changes-modal)
@@ -179,10 +179,9 @@
 
 (reg-event-fx
   ::enable-browser-back
-  (fn [{db :db} [_ event]]
+  (fn [{db :db}]
     (js/console.error "enable-ignore-modal")
-    {:db (assoc db ::routing-events/ignore-changes-protection true
-                   ::spec/after-clear-event event)
+    {:db (assoc db ::routing-events/ignore-changes-protection true)
      :fx [[::fx/enable-browser-back dispatch-after-clear-effect]]}))
 
 (reg-event-fx

--- a/code/src/cljs/sixsq/nuvla/ui/main/spec.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/spec.cljs
@@ -20,8 +20,8 @@
 (s/def ::nav-query-params any?)
 
 (s/def ::changes-protection? boolean?)
-
 (s/def ::ignore-changes-modal (s/nilable any?))
+(s/def ::after-clear-event (s/nilable any?))
 
 (s/def ::do-not-ignore-changes-modal (s/nilable any?))
 

--- a/code/src/cljs/sixsq/nuvla/ui/main/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/views.cljs
@@ -124,9 +124,11 @@
     (when @navigation-info
       (dispatch [::events/opening-protection-modal]))
 
-    [ui/Modal {:open       (some? @navigation-info)
-               :close-icon true
-               :on-close   ignore-changes-fn}
+    [ui/Modal {:open        (some? @navigation-info)
+               :close-icon  true
+               :on-close    ignore-changes-fn
+                ;; data-testid is used for e2e test
+               :data-testid "protection-modal"}
 
      [uix/ModalHeader {:header (@tr [:ignore-changes?])}]
 

--- a/code/src/cljs/sixsq/nuvla/ui/main/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/views.cljs
@@ -121,6 +121,8 @@
                               :template
                               (str/includes? "apps"))
         ignore-changes-fn #(dispatch [::events/ignore-changes false])]
+    (when @navigation-info
+      (dispatch [::events/disable-browser-back]))
 
     [ui/Modal {:open       (some? @navigation-info)
                :close-icon true

--- a/code/src/cljs/sixsq/nuvla/ui/main/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/views.cljs
@@ -115,18 +115,15 @@
 
 (defn ignore-changes-modal
   []
-  (let [tr                (subscribe [::i18n-subs/tr])
-        navigation-info   (subscribe [::subs/ignore-changes-modal])
-        on-apps-page?     (-> @(subscribe [::route-subs/current-route])
-                              :template
-                              (str/includes? "apps"))
-        ignore-changes-fn #(dispatch [::events/ignore-changes false])]
+  (let [tr                       (subscribe [::i18n-subs/tr])
+        navigation-info          (subscribe [::subs/ignore-changes-modal])
+        do-not-ignore-changes-fn #(dispatch [::events/ignore-changes false])]
     (when @navigation-info
       (dispatch [::events/opening-protection-modal]))
 
     [ui/Modal {:open        (some? @navigation-info)
                :close-icon  true
-               :on-close    ignore-changes-fn
+               :on-close    do-not-ignore-changes-fn
                 ;; data-testid is used for e2e test
                :data-testid "protection-modal"}
 
@@ -139,8 +136,7 @@
                    :positive true
                    :active   true
                    :on-click #(do (dispatch [::events/ignore-changes true])
-                                  (dispatch [::apps-events/form-valid])
-                                  (when on-apps-page? (dispatch [::apps-events/set-active-tab :overview])))}]]]))
+                                  (dispatch [::apps-events/form-valid]))}]]]))
 
 (defn subscription-required-modal
   []

--- a/code/src/cljs/sixsq/nuvla/ui/main/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/views.cljs
@@ -117,7 +117,7 @@
   []
   (let [tr                       (subscribe [::i18n-subs/tr])
         navigation-info          (subscribe [::subs/ignore-changes-modal])
-        do-not-ignore-changes-fn #(dispatch [::events/ignore-changes false])]
+        do-not-ignore-changes-fn #(dispatch [::events/do-not-ignore-changes])]
     (when @navigation-info
       (dispatch [::events/opening-protection-modal]))
 
@@ -135,7 +135,7 @@
       [uix/Button {:text     (@tr [:ignore-changes]),
                    :positive true
                    :active   true
-                   :on-click #(do (dispatch [::events/ignore-changes true])
+                   :on-click #(do (dispatch [::events/ignore-changes])
                                   (dispatch [::apps-events/form-valid]))}]]]))
 
 (defn subscription-required-modal

--- a/code/src/cljs/sixsq/nuvla/ui/main/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/views.cljs
@@ -121,8 +121,8 @@
                               :template
                               (str/includes? "apps"))
         ignore-changes-fn #(dispatch [::events/ignore-changes false])]
-    (when @navigation-info
-      (dispatch [::events/disable-browser-back]))
+    ;; (when @navigation-info
+    ;;   (dispatch [::events/disable-browser-back]))
 
     [ui/Modal {:open       (some? @navigation-info)
                :close-icon true

--- a/code/src/cljs/sixsq/nuvla/ui/main/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/views.cljs
@@ -121,8 +121,8 @@
                               :template
                               (str/includes? "apps"))
         ignore-changes-fn #(dispatch [::events/ignore-changes false])]
-    ;; (when @navigation-info
-    ;;   (dispatch [::events/disable-browser-back]))
+    (when @navigation-info
+      (dispatch [::events/opening-protection-modal]))
 
     [ui/Modal {:open       (some? @navigation-info)
                :close-icon true

--- a/code/src/cljs/sixsq/nuvla/ui/plugins/tab.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/plugins/tab.cljs
@@ -39,7 +39,7 @@
           normal-behavior {:db (assoc-in db (conj db-path ::active-tab) tab-key)
                            :fx [(when change-event
                                   [:dispatch change-event])
-                                [:dispatch [::main-events/changes-protection? false]]]}]
+                                [:dispatch [::main-events/reset-changes-protection]]]}]
       (if changes-protection?
         {:db (assoc db ::main-spec/ignore-changes-modal normal-behavior)}
         normal-behavior))))

--- a/code/src/cljs/sixsq/nuvla/ui/profile/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/profile/views.cljs
@@ -68,7 +68,7 @@
   [id]
   (swap! group-changed! assoc id false)
   (when-not (some true? (vals @group-changed!))
-    (dispatch [::main-events/changes-protection? false])))
+    (dispatch [::main-events/reset-changes-protection])))
 
 (defn AddGroupButton
   []

--- a/code/src/cljs/sixsq/nuvla/ui/routing/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/routing/events.cljs
@@ -64,7 +64,7 @@
                ;; disables the protection.
                ::ignore-changes-protection true)}
         (merge {:db (assoc db ::ignore-changes-protection false)}
-               event)))))
+          event)))))
 
 (reg-event-fx
   ::navigate
@@ -82,7 +82,6 @@
 (reg-event-fx
   ::navigate-partial
   (fn [{{:keys [current-route]} :db} [_ {:keys [change-event] :as new-partial-route-data}]]
-;; (js/console.error "::navigate-partial" new-partial-route-data)
     (let [{:keys [route-name
                   path-params
                   query-params]} (utils/new-route-data current-route new-partial-route-data)]

--- a/code/src/cljs/sixsq/nuvla/ui/routing/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/routing/events.cljs
@@ -16,7 +16,6 @@
   ::push-state-by-path
   (fn [{ {:keys [current-route
                  router]} :db} [_ new-path]]
-(js/console.error "HELLO pushing route")
     (let [new-match (dissoc (match-by-path router new-path) :controllers)]
       (when-not (= new-match (dissoc current-route :controllers))
         {::fx/push-state new-path}))))

--- a/code/src/cljs/sixsq/nuvla/ui/routing/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/routing/events.cljs
@@ -49,7 +49,6 @@
   ::navigated-protected
   (fn [{{:keys [::main-spec/changes-protection?
                 ::ignore-changes-protection] :as db} :db} [_ new-match]]
-    (js/console.error "::navigated-protected" new-match "changes-protection?" changes-protection?)
     (let [event  {:fx [[:dispatch [::navigated new-match]]
                        [:dispatch [::reset-ignore-changes-protection]]]}
           revert {:fx [[:dispatch [::navigate-back]]
@@ -72,7 +71,6 @@
   (fn [{{:keys [::main-spec/changes-protection?] :as db} :db} [_ navigate-to path-params query-params
                                                                {change-event :change-event
                                                                 ignore-chng-protection? :ignore-chng-protection?}]]
-    (js/console.error "::navigate" navigate-to "changes-protection?" changes-protection?)
     (let [nav-effect {:db (assoc db ::ignore-changes-protection ignore-chng-protection?)
                       :fx [[:dispatch [::push-state-by-path (if (string? navigate-to)
                                                               (utils/add-base-path navigate-to)
@@ -99,15 +97,16 @@
 
 (reg-event-fx
   ::change-query-param
-  (fn [{{:keys [current-route]} :db} [_ new-partial-route-data]]
+  (fn [{{:keys [current-route] :as db} :db} [_ new-partial-route-data]]
     (let [{:keys [route-name
                   path-params
                   query-params]} (utils/new-route-data current-route new-partial-route-data)]
-      {::fx/replace-state (utils/name->href route-name path-params query-params)})))
+      {:db (assoc db ::ignore-changes-protection true)
+       :fx [[::fx/replace-state (utils/name->href route-name path-params query-params)]]})))
 
 (reg-event-fx
   ::store-in-query-param
-  (fn [{{:keys [current-route]} :db} [_ {:keys [db-path value]}]]
+  (fn [{{:keys [current-route] :as db} :db} [_ {:keys [db-path value]}]]
     (let [query-key              (utils/db-path->query-param-key db-path)
           new-partial-route-data (if (seq value)
                                    {:partial-query-params

--- a/code/src/cljs/sixsq/nuvla/ui/routing/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/routing/events.cljs
@@ -49,6 +49,7 @@
   ::navigated-protected
   (fn [{{:keys [::main-spec/changes-protection?
                 ::ignore-changes-protection] :as db} :db} [_ new-match]]
+    (js/console.error "::navigated-protected" new-match "changes-protection?" changes-protection?)
     (let [event  {:fx [[:dispatch [::navigated new-match]]
                        [:dispatch [::reset-ignore-changes-protection]]]}
           revert {:fx [[:dispatch [::navigate-back]]
@@ -71,6 +72,7 @@
   (fn [{{:keys [::main-spec/changes-protection?] :as db} :db} [_ navigate-to path-params query-params
                                                                {change-event :change-event
                                                                 ignore-chng-protection? :ignore-chng-protection?}]]
+    (js/console.error "::navigate" navigate-to "changes-protection?" changes-protection?)
     (let [nav-effect {:db (assoc db ::ignore-changes-protection ignore-chng-protection?)
                       :fx [[:dispatch [::push-state-by-path (if (string? navigate-to)
                                                               (utils/add-base-path navigate-to)

--- a/code/src/cljs/sixsq/nuvla/ui/routing/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/routing/events.cljs
@@ -16,6 +16,7 @@
   ::push-state-by-path
   (fn [{ {:keys [current-route
                  router]} :db} [_ new-path]]
+(js/console.error "HELLO pushing route")
     (let [new-match (dissoc (match-by-path router new-path) :controllers)]
       (when-not (= new-match (dissoc current-route :controllers))
         {::fx/push-state new-path}))))

--- a/code/test/e2e/loggedin/apps_creation.spec.ts
+++ b/code/test/e2e/loggedin/apps_creation.spec.ts
@@ -79,7 +79,7 @@ test('Creating a new app', async ({ page }, { config }) => {
   await page.locator('a:has-text("Delete")').nth(1).click();
   await page.getByText('I understand that deleting this application is permanent and cannot be undone.').click();
   await page.getByRole('button', { name: 'delete' }).click();
-  await page.waitForURL(`${baseURL}/ui/apps`);
+  await page.waitForURL(new RegExp(`${baseURL}/ui/apps`));
 
   await page.pause();
   await page.getByRole('link', { name: 'My Apps' }).click();

--- a/code/test/e2e/loggedin/changes_protection_modal.spec.ts
+++ b/code/test/e2e/loggedin/changes_protection_modal.spec.ts
@@ -54,7 +54,7 @@ test('CHANGES PROTECTION MODAL TEST 1: opens by main navigation', async ({ page 
   // clicks X to close it
   // Open modal
   await openModal();
-  await page.locator('.close').click({ timeout: 2000 });
+  await page.locator('.close').click();
   expectModalHidden(page, 'Modal still hides after clicking X?');
   await page.goBack();
   await page.locator('.close').click({ timeout: 2000 });
@@ -62,8 +62,9 @@ test('CHANGES PROTECTION MODAL TEST 1: opens by main navigation', async ({ page 
 
   await openModal();
   expectModalHidden(page, 'Modal still hides after clicking X?', 200);
+  await page.pause();
   await page.getByRole('button', { name: 'ignore changes' }).click();
-  expect(page.url(), 'Final: Navigated to deployments page').toMatch(new RegExp(`${baseURL}/ui/deployments`));
+  expect(page.url(), 'Finally Navigated to deployments page').toMatch(new RegExp(`${baseURL}/ui/deployments`));
 });
 
 function testSameUrl(page, url: string, errorMessage = 'Same URL?') {

--- a/code/test/e2e/loggedin/changes_protection_modal.spec.ts
+++ b/code/test/e2e/loggedin/changes_protection_modal.spec.ts
@@ -1,55 +1,22 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
-test.use({ actionTimeout: 5000, navigationTimeout: 5000 });
+test.use({ actionTimeout: 10000, navigationTimeout: 10000 });
 
 test('CHANGES PROTECTION MODAL TEST 1: opens by main navigation', async ({ page }, { config }) => {
   const { baseURL } = config.projects[0].use;
   await page.goto(baseURL + '/ui/welcome');
 
   //
-  await page.pause();
+  // await page.pause();
 
   await setUp(page);
 
-  await page.pause();
+  // await page.pause();
   const url = page.url();
 
   ////////////////////////////////////
   // TESTING OPEN MODAL BY MAIN NAV //
   const openModal = () => page.getByRole('link', { name: 'deployments' }).click();
-
-  // CLICKS X for closing
-  await openModal();
-  await page.locator('.close').click();
-  expectModalHidden(page, 'Modal hidden after click on X');
-  testSameUrl(page, url, 'Same URL after click on X');
-
-  // NAVIGATE BACK for closing
-  await openModal();
-  await page.goBack();
-  expectModalHidden(page, 'Modal hidden after navigating back');
-  testSameUrl(page, url, 'Same URL after navigating back');
-
-  // CLICKS OUTSIDE MODAL for closing
-  // FIX ME: This test passes in headed and fails in headless mode.
-  // await openModal();
-  // next two lines do the same, only use need one
-  // await page.evaluate(() => document.querySelector('[data-testid=protection-modal]')?.parentElement?.click());
-  // await page.getByTestId('protection-modal').locator('..').click();
-  // expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden();
-  // expect(page.url()).toBe(url);
-
-  // //// TEST IGNORE CASE ////
-  // //////////////////////////
-
-  // TODO: Test if all protections are still in place
-  // clicks X to close it
-  // Open modal
-  await openModal();
-  await page.locator('.close').click({ timeout: 2000 });
-  expectModalHidden(page, 'Modal still hides after clicking X?');
-  // await page.goBack();
-  // await page.locator('.close').click({ timeout: 2000 });
 
   await openModal();
 
@@ -57,88 +24,42 @@ test('CHANGES PROTECTION MODAL TEST 1: opens by main navigation', async ({ page 
   await page.getByRole('button', { name: 'ignore changes' }).click();
   expectModalHidden(page, 'Modal hidden after ignoring changes');
   page.waitForURL(new RegExp('https://nui.localhost/ui/deployments'), { timeout: 2000 });
-});
 
-test.skip('CHANGES PROTECTION MODAL TEST 2: opens by navigating back', async ({ page }, { config }) => {
-  const { baseURL } = config.projects[0].use;
-  await page.goto(baseURL + '/ui/welcome');
-
-  //
-  await page.pause();
   await setUp(page);
-  await page.pause();
-  const url = page.url();
 
-  ////////////////////////////////////
-  // TESTING OPEN MODAL BY MAIN NAV //
-  const openModalByNavBack = () => page.getByRole('link', { name: 'deployments' }).click();
+  // await page.pause();
 
   // CLICKS X for closing
-  await openModalByNavBack();
+  await openModal();
+  await page.waitForTimeout(200);
   await page.locator('.close').click();
-  expectModalHidden(page, 'Modal hidden after click on X');
+  expectModalHidden(page, 'Modal hidden after click on X', 200);
   testSameUrl(page, url, 'Same URL after click on X');
 
   // NAVIGATE BACK for closing
-  await openModalByNavBack();
+  await openModal();
+  await page.waitForTimeout(200);
   await page.goBack();
   expectModalHidden(page, 'Modal hidden after navigating back');
   testSameUrl(page, url, 'Same URL after navigating back');
 
   // CLICKS OUTSIDE MODAL for closing
-  // FIX ME: This test passes in headed and fails in headless mode.
-  // await openModal();
+  await openModal();
   // next two lines do the same, only use need one
-  // await page.evaluate(() => document.querySelector('[data-testid=protection-modal]')?.parentElement?.click());
+  await page.waitForTimeout(100);
+  await page.evaluate(() => document.querySelector('[data-testid=protection-modal]')?.parentElement?.click());
   // await page.getByTestId('protection-modal').locator('..').click();
-  // expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden();
-  // expect(page.url()).toBe(url);
+  expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden();
+  expect(page.url()).toBe(url);
 
-  // ////////////////////////////////////
-  // // TESTING OPEN MODAL BY MAIN NAV //
-  // const openModalByBrowserBack = () => page.goBack();
-
-  // // CLICKS X for closing
-  // await openModalByBrowserBack();
-  // await page.locator('.close').click({ timeout: 2000 });
-  // testModalhidden(page);
-  // expect(page.url()).toBe(url);
-
-  // // NAVIGATE BACK for closing
-  // await openModalByBrowserBack();
-  // await page.goBack();
-  // testModalhidden(page);
-  // expect(page.url()).toBe(url);
-
-  // // CLICKS OUTSIDE MODAL for closing
-  // // FIX ME: This test passes in headed and fails in headless mode.
-  // // await openModalByBrowserBack();
-  // // next two lines do the same, only use need one
-  // // await page.evaluate(() => document.querySelector('[data-testid=protection-modal]')?.parentElement?.click());
-  // // await page.getByTestId('protection-modal').locator('..').click();
-  // // expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden();
-  // // expect(page.url()).toBe(url);
-
-  // //////////////////////////
-  // //////////////////////////
-  // //////////////////////////
-  // //////////////////////////
-  // //// TEST IGNORE CASE ////
-  // //////////////////////////
-  await openModalByNavBack();
-
-  // TODO: Test if all protections are still in place
+  // Test if all protections are still in place
   // clicks X to close it
   // Open modal
-  expectModalVisible(page);
-  await page.locator('.close').click();
-
-  await openModalByNavBack();
-
-  // ignores changes
-  await page.getByRole('button', { name: 'ignore changes' }).click();
-  expectModalHidden(page, 'Modal hidden after ignoring changes', 2000);
-  page.waitForURL(new RegExp('https://nui.localhost/ui/deployments'), { timeout: 2000 });
+  await openModal();
+  await page.locator('.close').click({ timeout: 2000 });
+  expectModalHidden(page, 'Modal still hides after clicking X?');
+  await page.goBack();
+  await page.locator('.close').click({ timeout: 2000 });
 });
 
 test.skip('CHANGES PROTECTION MODAL TEST 1b: opens by main navigation, and closes by navigating back', async ({
@@ -148,7 +69,7 @@ test.skip('CHANGES PROTECTION MODAL TEST 1b: opens by main navigation, and close
   await page.goto(baseURL + '/ui/welcome');
 
   //
-  await page.pause();
+  // await page.pause();
 
   await setUp(page);
   const url = page.url();
@@ -157,49 +78,6 @@ test.skip('CHANGES PROTECTION MODAL TEST 1b: opens by main navigation, and close
   await page.goBack();
   expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden({ timeout: 2000 });
   expect(page.url()).toBe(url);
-});
-
-// TODO:
-test.skip('CHANGES PROTECTION MODAL TEST 2: opens by clicking link handled by reitit, and closes by ignore changes click', async ({
-  page,
-}, { config }) => {
-  const { baseURL } = config.projects[0].use;
-  await page.goto(baseURL + '/ui/welcome');
-
-  //
-  // await page.pause();
-
-  await page.getByRole('link', { name: 'apps' }).click();
-  await page.waitForURL('https://nui.localhost/ui/apps');
-  await page.getByRole('link', { name: 'Navigate Apps' }).click();
-  await page.waitForURL('https://nui.localhost/ui/apps?apps-store-tab=navigate');
-  await page.getByText('DO NOT DELETE --- e2e test project').click();
-  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview');
-  await page.getByRole('link', { name: 'Details' }).click();
-  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details');
-  await page.locator('input[type="input"]').click();
-  await page.locator('input[type="input"]').fill('DO NOT DELETE --- e2e test project. ');
-  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details');
-  await page.getByRole('button', { name: 'ignore changes' }).click();
-  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details');
-  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview');
-});
-
-test.skip('CHANGES PROTECTION MODAL TEST 3: opens by navigating back, 2) and closes by ignore changes click', async ({
-  page,
-}, { config }) => {
-  const { baseURL } = config.projects[0].use;
-  await page.goto(baseURL + '/ui/welcome');
-
-  //
-  await page.pause();
-
-  await setUp(page);
-  await page.goBack();
-  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details');
-  await page.getByRole('button', { name: 'ignore changes' }).click();
-  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details');
-  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview');
 });
 
 function testSameUrl(page, url: string, errorMessage = 'Same URL?') {
@@ -214,12 +92,13 @@ function expectModalHidden(page, errorMessage = 'Modal hidden?', timeout = 0) {
   expect(page.getByRole('button', { name: 'ignore changes' }), errorMessage).toBeHidden({ timeout });
 }
 
-async function setUp(page) {
+async function setUp(page: Page) {
   await page.getByRole('link', { name: 'apps' }).click();
   await page.waitForURL('https://nui.localhost/ui/apps');
   await page.getByRole('link', { name: 'Navigate Apps' }).click();
   await page.waitForURL('https://nui.localhost/ui/apps?apps-store-tab=navigate');
-  await page.getByText('DO NOT DELETE --- e2e test project').click();
+  // await page.pause();
+  await page.getByText('DO NOT DELETE --- e2e test project', { exact: true }).click();
   await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview');
   await page
     .locator('main:has-text("Validation error!The form is invalid. Please review the fields in red.Oops can\'t")')

--- a/code/test/e2e/loggedin/changes_protection_modal.spec.ts
+++ b/code/test/e2e/loggedin/changes_protection_modal.spec.ts
@@ -9,7 +9,7 @@ test('CHANGES PROTECTION MODAL TEST 1: opens by main navigation', async ({ page 
   //
   // await page.pause();
 
-  await setUp(page);
+  await setUp(page, baseURL);
 
   // await page.pause();
   const url = page.url();
@@ -22,9 +22,9 @@ test('CHANGES PROTECTION MODAL TEST 1: opens by main navigation', async ({ page 
 
   // ignores changes
   await page.getByRole('button', { name: 'ignore changes' }).click();
-  page.waitForURL(new RegExp('https://nui.localhost/ui/deployments'), { timeout: 2000 });
+  page.waitForURL(new RegExp(`${baseURL}/ui/deployments`), { timeout: 2000 });
 
-  await setUp(page);
+  await setUp(page, baseURL);
 
   // await page.pause();
 
@@ -90,25 +90,23 @@ function expectModalHidden(page, errorMessage = 'Modal hidden?', timeout = 0) {
   expect(page.getByRole('button', { name: 'ignore changes' }), errorMessage).toBeHidden({ timeout });
 }
 
-async function setUp(page: Page) {
+async function setUp(page: Page, baseURL) {
   await page.getByRole('link', { name: 'apps' }).click();
-  await page.waitForURL('https://nui.localhost/ui/apps');
+  await page.waitForURL(`${baseURL}/ui/apps`);
   await page.getByRole('link', { name: 'Navigate Apps' }).click();
-  await page.waitForURL('https://nui.localhost/ui/apps?apps-store-tab=navigate');
+  await page.waitForURL(`${baseURL}/ui/apps?apps-store-tab=navigate`);
   // await page.pause();
   await page.getByText('DO NOT DELETE --- e2e test project', { exact: true }).click();
-  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview');
+  await page.waitForURL(`${baseURL}/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview`);
   await page
     .locator('main:has-text("Validation error!The form is invalid. Please review the fields in red.Oops can\'t")')
     .getByRole('button')
     .click();
   await page.waitForURL(
-    'https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview&apps-tab=details'
+    `${baseURL}/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview&apps-tab=details`
   );
   await page.getByRole('link', { name: 'Details' }).click();
-  await page.waitForURL(
-    'https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details&apps-tab=details'
-  );
+  await page.waitForURL(`${baseURL}/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details&apps-tab=details`);
   await page.locator('input[type="input"]').click();
   return page.locator('input[type="input"]').fill('DO NOT DELETE --- e2e test project HELLO');
 }

--- a/code/test/e2e/loggedin/changes_protection_modal.spec.ts
+++ b/code/test/e2e/loggedin/changes_protection_modal.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+
+test('CHANGES PROTECTION MODAL TEST 1a: opens by main navigation, and closes by ignore changes click', async ({
+  page,
+}, { config }) => {
+  const { baseURL } = config.projects[0].use;
+  await page.goto(baseURL + '/ui/welcome');
+
+  //
+  await page.pause();
+
+  await setUp(page);
+  await page.getByRole('link', { name: 'deployments' }).click();
+  await page.getByRole('button', { name: 'ignore changes' }).click();
+
+  expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden({ timeout: 2000 });
+  await page.waitForURL('https://nui.localhost/ui/deployments');
+});
+
+test('CHANGES PROTECTION MODAL TEST 1b: opens by main navigation, and closes by navigating back', async ({ page }, {
+  config,
+}) => {
+  const { baseURL } = config.projects[0].use;
+  await page.goto(baseURL + '/ui/welcome');
+
+  //
+  await page.pause();
+
+  await setUp(page);
+  const url = page.url();
+
+  await page.getByRole('link', { name: 'deployments' }).click();
+  await page.goBack();
+  expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden({ timeout: 2000 });
+  expect(page.url()).toBe(url);
+});
+
+// TODO:
+test.skip('CHANGES PROTECTION MODAL TEST 2: opens by clicking link handled by reitit, and closes by ignore changes click', async ({
+  page,
+}, { config }) => {
+  const { baseURL } = config.projects[0].use;
+  await page.goto(baseURL + '/ui/welcome');
+
+  //
+  // await page.pause();
+
+  await page.getByRole('link', { name: 'apps' }).click();
+  await page.waitForURL('https://nui.localhost/ui/apps');
+  await page.getByRole('link', { name: 'Navigate Apps' }).click();
+  await page.waitForURL('https://nui.localhost/ui/apps?apps-store-tab=navigate');
+  await page.getByText('DO NOT DELETE --- e2e test project').click();
+  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview');
+  await page.getByRole('link', { name: 'Details' }).click();
+  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details');
+  await page.locator('input[type="input"]').click();
+  await page.locator('input[type="input"]').fill('DO NOT DELETE --- e2e test project. ');
+  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details');
+  await page.getByRole('button', { name: 'ignore changes' }).click();
+  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details');
+  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview');
+});
+
+test.skip('CHANGES PROTECTION MODAL TEST 3: opens by navigating back, 2) and closes by ignore changes click', async ({
+  page,
+}, { config }) => {
+  const { baseURL } = config.projects[0].use;
+  await page.goto(baseURL + '/ui/welcome');
+
+  //
+  await page.pause();
+
+  await setUp(page);
+  await page.goBack();
+  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details');
+  await page.getByRole('button', { name: 'ignore changes' }).click();
+  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details');
+  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview');
+});
+
+async function setUp(page) {
+  await page.getByRole('link', { name: 'apps' }).click();
+  await page.waitForURL('https://nui.localhost/ui/apps');
+  await page.getByRole('link', { name: 'Navigate Apps' }).click();
+  await page.waitForURL('https://nui.localhost/ui/apps?apps-store-tab=navigate');
+  await page.getByText('DO NOT DELETE --- e2e test project').click();
+  await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview');
+  await page
+    .locator('main:has-text("Validation error!The form is invalid. Please review the fields in red.Oops can\'t")')
+    .getByRole('button')
+    .click();
+  await page.waitForURL(
+    'https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview&apps-tab=details'
+  );
+  await page.getByRole('link', { name: 'Details' }).click();
+  await page.waitForURL(
+    'https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details&apps-tab=details'
+  );
+  await page.locator('input[type="input"]').click();
+  return page.locator('input[type="input"]').fill('DO NOT DELETE --- e2e test project HELLO');
+}

--- a/code/test/e2e/loggedin/changes_protection_modal.spec.ts
+++ b/code/test/e2e/loggedin/changes_protection_modal.spec.ts
@@ -83,18 +83,11 @@ async function setUp(page: Page, baseURL) {
   await page.waitForURL(`${baseURL}/ui/apps`);
   await page.getByRole('link', { name: 'Navigate Apps' }).click();
   await page.waitForURL(`${baseURL}/ui/apps?apps-store-tab=navigate`);
-  // await page.pause();
+  await page.pause();
   await page.getByText('DO NOT DELETE --- e2e test project', { exact: true }).click();
   await page.waitForURL(`${baseURL}/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview`);
-  await page
-    .locator('main:has-text("Validation error!The form is invalid. Please review the fields in red.Oops can\'t")')
-    .getByRole('button')
-    .click();
-  await page.waitForURL(
-    `${baseURL}/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview&apps-tab=details`
-  );
   await page.getByRole('link', { name: 'Details' }).click();
-  await page.waitForURL(`${baseURL}/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details&apps-tab=details`);
+  await page.waitForURL(`${baseURL}/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details`);
   await page.locator('input[type="input"]').click();
   return page.locator('input[type="input"]').fill('DO NOT DELETE --- e2e test project HELLO');
 }

--- a/code/test/e2e/loggedin/changes_protection_modal.spec.ts
+++ b/code/test/e2e/loggedin/changes_protection_modal.spec.ts
@@ -38,7 +38,7 @@ test('CHANGES PROTECTION MODAL TEST 1: opens by main navigation', async ({ page 
   await openModal();
   await page.waitForTimeout(200);
   await page.goBack();
-  expectModalHidden(page, 'Modal hidden after navigating back');
+  expectModalHidden(page, 'Modal hidden after navigating back 1st time');
   testSameUrl(page, url, 'Same URL after navigating back');
 
   // CLICKS OUTSIDE MODAL for closing
@@ -58,24 +58,12 @@ test('CHANGES PROTECTION MODAL TEST 1: opens by main navigation', async ({ page 
   expectModalHidden(page, 'Modal still hides after clicking X?');
   await page.goBack();
   await page.locator('.close').click({ timeout: 2000 });
-});
+  expectModalHidden(page, 'Modal still after navigating back 2nd time?');
 
-test.skip('CHANGES PROTECTION MODAL TEST 1b: opens by main navigation, and closes by navigating back', async ({
-  page,
-}, { config }) => {
-  const { baseURL } = config.projects[0].use;
-  await page.goto(baseURL + '/ui/welcome');
-
-  //
-  // await page.pause();
-
-  await setUp(page);
-  const url = page.url();
-
-  await page.getByRole('link', { name: 'deployments' }).click();
-  await page.goBack();
-  expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden({ timeout: 2000 });
-  expect(page.url()).toBe(url);
+  await openModal();
+  expectModalHidden(page, 'Modal still hides after clicking X?', 200);
+  await page.getByRole('button', { name: 'ignore changes' }).click();
+  expect(page.url(), 'Final: Navigated to deployments page').toMatch(new RegExp(`${baseURL}/ui/deployments`));
 });
 
 function testSameUrl(page, url: string, errorMessage = 'Same URL?') {

--- a/code/test/e2e/loggedin/changes_protection_modal.spec.ts
+++ b/code/test/e2e/loggedin/changes_protection_modal.spec.ts
@@ -22,7 +22,6 @@ test('CHANGES PROTECTION MODAL TEST 1: opens by main navigation', async ({ page 
 
   // ignores changes
   await page.getByRole('button', { name: 'ignore changes' }).click();
-  expectModalHidden(page, 'Modal hidden after ignoring changes');
   page.waitForURL(new RegExp('https://nui.localhost/ui/deployments'), { timeout: 2000 });
 
   await setUp(page);
@@ -33,7 +32,6 @@ test('CHANGES PROTECTION MODAL TEST 1: opens by main navigation', async ({ page 
   await openModal();
   await page.waitForTimeout(200);
   await page.locator('.close').click();
-  expectModalHidden(page, 'Modal hidden after click on X', 200);
   testSameUrl(page, url, 'Same URL after click on X');
 
   // NAVIGATE BACK for closing

--- a/code/test/e2e/loggedin/changes_protection_modal.spec.ts
+++ b/code/test/e2e/loggedin/changes_protection_modal.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test('CHANGES PROTECTION MODAL TEST 1a: opens by main navigation, and closes by ignore changes click', async ({
+test.only('CHANGES PROTECTION MODAL TEST 1a: opens by main navigation, and closes by ignore changes click', async ({
   page,
 }, { config }) => {
   const { baseURL } = config.projects[0].use;
@@ -10,9 +10,38 @@ test('CHANGES PROTECTION MODAL TEST 1a: opens by main navigation, and closes by 
   await page.pause();
 
   await setUp(page);
-  await page.getByRole('link', { name: 'deployments' }).click();
-  await page.getByRole('button', { name: 'ignore changes' }).click();
 
+  await page.pause();
+
+  const openModal = () => page.getByRole('link', { name: 'deployments' }).click();
+  const url = page.url();
+
+  // clicks X to close it
+  await openModal();
+  await page.locator('.close').click();
+  testModalhidden(page);
+  expect(page.url()).toBe(url);
+
+  // clicks outside modal for closing it
+  // await page.evaluate(() => document.querySelector('[data-testid=protection-modal]')?.parentElement?.click());
+  // await openModal();
+  // await page.getByTestId('protection-modal').locator('..').click();
+  // expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden();
+  // expect(page.url()).toBe(url);
+
+  await openModal();
+
+  // navigate back for closing modal
+  await page.goBack();
+  testModalhidden(page);
+  expect(page.url()).toBe(url);
+
+  // TODO: Test if all protections are still in place
+
+  await openModal();
+
+  // ignores changes
+  await page.getByRole('button', { name: 'ignore changes' }).click();
   expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden({ timeout: 2000 });
   await page.waitForURL('https://nui.localhost/ui/deployments');
 });
@@ -77,6 +106,10 @@ test.skip('CHANGES PROTECTION MODAL TEST 3: opens by navigating back, 2) and clo
   await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=details');
   await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview');
 });
+
+function testModalhidden(page) {
+  expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden();
+}
 
 async function setUp(page) {
   await page.getByRole('link', { name: 'apps' }).click();

--- a/code/test/e2e/loggedin/changes_protection_modal.spec.ts
+++ b/code/test/e2e/loggedin/changes_protection_modal.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test';
 
-test.only('CHANGES PROTECTION MODAL TEST 1a: opens by main navigation, and closes by ignore changes click', async ({
-  page,
-}, { config }) => {
+test.use({ actionTimeout: 5000, navigationTimeout: 5000 });
+
+test('CHANGES PROTECTION MODAL TEST 1: opens by main navigation', async ({ page }, { config }) => {
   const { baseURL } = config.projects[0].use;
   await page.goto(baseURL + '/ui/welcome');
 
@@ -12,43 +12,138 @@ test.only('CHANGES PROTECTION MODAL TEST 1a: opens by main navigation, and close
   await setUp(page);
 
   await page.pause();
-
-  const openModal = () => page.getByRole('link', { name: 'deployments' }).click();
   const url = page.url();
 
-  // clicks X to close it
+  ////////////////////////////////////
+  // TESTING OPEN MODAL BY MAIN NAV //
+  const openModal = () => page.getByRole('link', { name: 'deployments' }).click();
+
+  // CLICKS X for closing
   await openModal();
   await page.locator('.close').click();
-  testModalhidden(page);
-  expect(page.url()).toBe(url);
+  expectModalHidden(page, 'Modal hidden after click on X');
+  testSameUrl(page, url, 'Same URL after click on X');
 
-  // clicks outside modal for closing it
-  // await page.evaluate(() => document.querySelector('[data-testid=protection-modal]')?.parentElement?.click());
+  // NAVIGATE BACK for closing
+  await openModal();
+  await page.goBack();
+  expectModalHidden(page, 'Modal hidden after navigating back');
+  testSameUrl(page, url, 'Same URL after navigating back');
+
+  // CLICKS OUTSIDE MODAL for closing
+  // FIX ME: This test passes in headed and fails in headless mode.
   // await openModal();
+  // next two lines do the same, only use need one
+  // await page.evaluate(() => document.querySelector('[data-testid=protection-modal]')?.parentElement?.click());
   // await page.getByTestId('protection-modal').locator('..').click();
   // expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden();
   // expect(page.url()).toBe(url);
 
-  await openModal();
-
-  // navigate back for closing modal
-  await page.goBack();
-  testModalhidden(page);
-  expect(page.url()).toBe(url);
+  // //// TEST IGNORE CASE ////
+  // //////////////////////////
 
   // TODO: Test if all protections are still in place
+  // clicks X to close it
+  // Open modal
+  await openModal();
+  await page.locator('.close').click({ timeout: 2000 });
+  expectModalHidden(page, 'Modal still hides after clicking X?');
+  // await page.goBack();
+  // await page.locator('.close').click({ timeout: 2000 });
 
   await openModal();
 
   // ignores changes
   await page.getByRole('button', { name: 'ignore changes' }).click();
-  expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden({ timeout: 2000 });
-  await page.waitForURL('https://nui.localhost/ui/deployments');
+  expectModalHidden(page, 'Modal hidden after ignoring changes');
+  page.waitForURL(new RegExp('https://nui.localhost/ui/deployments'), { timeout: 2000 });
 });
 
-test('CHANGES PROTECTION MODAL TEST 1b: opens by main navigation, and closes by navigating back', async ({ page }, {
-  config,
-}) => {
+test.skip('CHANGES PROTECTION MODAL TEST 2: opens by navigating back', async ({ page }, { config }) => {
+  const { baseURL } = config.projects[0].use;
+  await page.goto(baseURL + '/ui/welcome');
+
+  //
+  await page.pause();
+  await setUp(page);
+  await page.pause();
+  const url = page.url();
+
+  ////////////////////////////////////
+  // TESTING OPEN MODAL BY MAIN NAV //
+  const openModalByNavBack = () => page.getByRole('link', { name: 'deployments' }).click();
+
+  // CLICKS X for closing
+  await openModalByNavBack();
+  await page.locator('.close').click();
+  expectModalHidden(page, 'Modal hidden after click on X');
+  testSameUrl(page, url, 'Same URL after click on X');
+
+  // NAVIGATE BACK for closing
+  await openModalByNavBack();
+  await page.goBack();
+  expectModalHidden(page, 'Modal hidden after navigating back');
+  testSameUrl(page, url, 'Same URL after navigating back');
+
+  // CLICKS OUTSIDE MODAL for closing
+  // FIX ME: This test passes in headed and fails in headless mode.
+  // await openModal();
+  // next two lines do the same, only use need one
+  // await page.evaluate(() => document.querySelector('[data-testid=protection-modal]')?.parentElement?.click());
+  // await page.getByTestId('protection-modal').locator('..').click();
+  // expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden();
+  // expect(page.url()).toBe(url);
+
+  // ////////////////////////////////////
+  // // TESTING OPEN MODAL BY MAIN NAV //
+  // const openModalByBrowserBack = () => page.goBack();
+
+  // // CLICKS X for closing
+  // await openModalByBrowserBack();
+  // await page.locator('.close').click({ timeout: 2000 });
+  // testModalhidden(page);
+  // expect(page.url()).toBe(url);
+
+  // // NAVIGATE BACK for closing
+  // await openModalByBrowserBack();
+  // await page.goBack();
+  // testModalhidden(page);
+  // expect(page.url()).toBe(url);
+
+  // // CLICKS OUTSIDE MODAL for closing
+  // // FIX ME: This test passes in headed and fails in headless mode.
+  // // await openModalByBrowserBack();
+  // // next two lines do the same, only use need one
+  // // await page.evaluate(() => document.querySelector('[data-testid=protection-modal]')?.parentElement?.click());
+  // // await page.getByTestId('protection-modal').locator('..').click();
+  // // expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden();
+  // // expect(page.url()).toBe(url);
+
+  // //////////////////////////
+  // //////////////////////////
+  // //////////////////////////
+  // //////////////////////////
+  // //// TEST IGNORE CASE ////
+  // //////////////////////////
+  await openModalByNavBack();
+
+  // TODO: Test if all protections are still in place
+  // clicks X to close it
+  // Open modal
+  expectModalVisible(page);
+  await page.locator('.close').click();
+
+  await openModalByNavBack();
+
+  // ignores changes
+  await page.getByRole('button', { name: 'ignore changes' }).click();
+  expectModalHidden(page, 'Modal hidden after ignoring changes', 2000);
+  page.waitForURL(new RegExp('https://nui.localhost/ui/deployments'), { timeout: 2000 });
+});
+
+test.skip('CHANGES PROTECTION MODAL TEST 1b: opens by main navigation, and closes by navigating back', async ({
+  page,
+}, { config }) => {
   const { baseURL } = config.projects[0].use;
   await page.goto(baseURL + '/ui/welcome');
 
@@ -107,8 +202,16 @@ test.skip('CHANGES PROTECTION MODAL TEST 3: opens by navigating back, 2) and clo
   await page.waitForURL('https://nui.localhost/ui/apps/do-not-delete--e2e-test-project?apps-project-tab=overview');
 });
 
-function testModalhidden(page) {
-  expect(page.getByRole('button', { name: 'ignore changes' })).toBeHidden();
+function testSameUrl(page, url: string, errorMessage = 'Same URL?') {
+  expect(page.url(), errorMessage).toBe(url);
+}
+
+function expectModalVisible(page, errorMessage = 'Modal visible?') {
+  expect(page.getByRole('button', { name: 'ignore changes' }), errorMessage).toBeVisible({ timeout: 2000 });
+}
+
+function expectModalHidden(page, errorMessage = 'Modal hidden?', timeout = 0) {
+  expect(page.getByRole('button', { name: 'ignore changes' }), errorMessage).toBeHidden({ timeout });
 }
 
 async function setUp(page) {

--- a/code/test/e2e/loggedin/nuvlaedge.spec.js
+++ b/code/test/e2e/loggedin/nuvlaedge.spec.js
@@ -26,7 +26,8 @@ test('NuvlaEdge creation and deletion', async ({ page, context }, { project, con
 
   await page.getByText('Enable host-level management').click();
 
-  const newEdgeName = `e2e Testing: Edge creation and deletion in ${project.name} ${new Date().toISOString()}`;
+  const newEdgeNameStart = `e2e Testing: Edge creation and deletion in`;
+  const newEdgeName = `${newEdgeNameStart} ${project.name} ${new Date().toISOString()}`;
 
   await page.locator('input[type="input"]').click();
   await page.locator('input[type="input"]').fill(newEdgeName);
@@ -46,6 +47,12 @@ test('NuvlaEdge creation and deletion', async ({ page, context }, { project, con
   await page.getByText(/^delete$/i).click();
   await page.getByRole('button', { name: 'delete' }).click();
   await expect(page).toHaveURL(edgesPageRegex);
+
+  await page.getByPlaceholder('Search ...').click();
+  page.getByPlaceholder('Search ...').fill(newEdgeNameStart);
+  await page.waitForResponse('/api/nuvlabox');
+  await page.waitForTimeout(200);
+  expect(await page.getByRole('link', { name: new RegExp(newEdgeNameStart) }).count()).toBe(0);
 
   // This is a workaround to test clipboard content if cronjob is copied
   // see: https://github.com/microsoft/playwright/issues/8114

--- a/code/test/e2e/loggedin/nuvlaedge_deletions.spec.ts
+++ b/code/test/e2e/loggedin/nuvlaedge_deletions.spec.ts
@@ -28,7 +28,7 @@ test('Deletes all nuvlaedges created through e2e tests', async ({ page, context 
     await page.locator('a:has-text("delete")').click();
     // await page.pause();
     await page.getByRole('button', { name: 'delete' }).click();
-    await page.waitForURL('https://nui.localhost/ui/edges?view=table');
+    await page.waitForURL(`${baseURL}/ui/edges?view=table`);
     await page.getByPlaceholder('Search ...').click();
     page.getByPlaceholder('Search ...').fill(newEdgeName);
     await page.waitForResponse('/api/nuvlabox');

--- a/code/test/e2e/loggedin/nuvlaedge_deletions.spec.ts
+++ b/code/test/e2e/loggedin/nuvlaedge_deletions.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+// e2e edges deletion script
+test('Deletes all nuvlaedges created through e2e tests', async ({ page, context }, { project, config }) => {
+  const { baseURL } = config.projects[0].use;
+  await page.goto(baseURL + '/ui/welcome');
+  await page.getByRole('link', { name: 'Edges' }).click();
+
+  await page.pause();
+  const edgesPageRegex = /\/ui\/edges/;
+
+  await expect(page).toHaveURL(edgesPageRegex);
+  await page.getByText('25 per page').click();
+  await page.getByRole('option', { name: '100' }).getByText('100').click();
+
+  const newEdgeName = `e2e Testing: Edge creation and deletion in`;
+  await page.getByPlaceholder('Search ...').click();
+  page.getByPlaceholder('Search ...').fill(newEdgeName);
+  await page.waitForResponse('/api/nuvlabox');
+  await page.waitForTimeout(1000);
+
+  let found = await page.getByRole('link', { name: new RegExp(newEdgeName) }).count();
+  while (found > 0) {
+    await page
+      .getByRole('link', { name: new RegExp(newEdgeName) })
+      .nth(0)
+      .click({ timeout: 5000 });
+    await page.locator('a:has-text("delete")').click();
+    // await page.pause();
+    await page.getByRole('button', { name: 'delete' }).click();
+    await page.waitForURL('https://nui.localhost/ui/edges?view=table');
+    await page.getByPlaceholder('Search ...').click();
+    page.getByPlaceholder('Search ...').fill(newEdgeName);
+    await page.waitForResponse('/api/nuvlabox');
+    await page.waitForTimeout(500);
+    // await page.pause();
+    found = await page.getByRole('link', { name: new RegExp(newEdgeName) }).count();
+  }
+});

--- a/code/test/e2e/loggedin/projects_apps_navigate.spec.ts
+++ b/code/test/e2e/loggedin/projects_apps_navigate.spec.ts
@@ -14,8 +14,9 @@ test('Navigate from projects to apps', async ({ page }, { config }) => {
   await expect(page).toHaveURL(new RegExp(`${baseURL}/ui/apps/do-not-delete--e2e-test-project`));
 
   await page.getByText('DO NOT DELETE -- e2e test app').click();
-  await expect(page).toHaveURL(`${baseURL}/ui/apps/do-not-delete--e2e-test-project/do-not-delete--e2e-test-app?apps-tab=overview`);
+  await expect(page).toHaveURL(
+    new RegExp(`${baseURL}/ui/apps/do-not-delete--e2e-test-project/do-not-delete--e2e-test-app`)
+  );
   await expect(page).toHaveTitle('Nuvla apps/do-not-delete--e2e-test-project/do-not-delete--e2e-test-app');
-  await expect(page.getByRole('cell', { name: 'DO NOT DELETE -- e2e test app'})).toBeVisible();
-
+  await expect(page.getByRole('cell', { name: 'DO NOT DELETE -- e2e test app' })).toBeVisible();
 });


### PR DESCRIPTION
([this one should be merged first](https://github.com/nuvla/ui/pull/1173), so I can fix merge conflicts afterwards)

All's fixed now but it's not a beauty and should be refactored.
1. All change protection stuff needs its own namespace(s).
2. The whole thing should be an explicit explicit state machine ("explicit" because every app is an implicit one), e.g. we need to know how the change-protection-modal was opened (i.e. by a navigate back event, or a link click)
3. Example for state machine inside re-frame: https://cognitect.com/blog/2017/8/14/restate-your-ui-creating-a-user-interface-with-re-frame-and-state-machines (haven't read all of it yet, just searched in Clojurians Slack re-frame channel)
