### PR TITLE
Fix for: emptying a non-mandatory variable returns 400 error

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/deployment_sets_detail/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/deployment_sets_detail/events.cljs
@@ -367,6 +367,7 @@
                 (map (juxt :name :value))
                 (into {}))]
     (->> (merge m1 m2)
+         (remove (fn [[_ v]] (str/blank? v)))
          (mapv (fn [[k v]] {:name k :value v})))))
 
 (defn application-overwrites


### PR DESCRIPTION
Fixes SixSq/tasklist#2675
