### PR TITLE
Fix for: Adding a deployment group with apps and then cancelling the creation keeps previously selected applications cached

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/deployment_sets_detail/spec.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/deployment_sets_detail/spec.cljs
@@ -39,6 +39,7 @@
 
 (s/def ::opened-modal (s/nilable keyword?))
 
+(s/def ::apps-creation any?)
 (s/def ::apps-edited? boolean?)
 (s/def ::listed-apps-by-id any?)
 
@@ -79,6 +80,7 @@
                                  :default-items-per-page 16)
    ::edge-picker-pagination    pagination-default
    ::opened-modal              nil
+   ::apps-creation             nil
    ::apps-edited?              false
    ::fleet-filter              nil
    ::fleet-filter-edited       nil})

--- a/code/src/cljs/sixsq/nuvla/ui/deployments/routes.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/deployments/routes.cljs
@@ -21,17 +21,17 @@
 
 (defn DeploymentTabItem
   [{:keys [active? href label icon]}]
-  [:a {:href   href
-       :style  (cond->
-                 {:align-self          :flex-end
-                  :margin              "0 0 -2px"
-                  :padding             ".85714286em 1.14285714em"
-                  :border-bottom-width "2px"
-                  :transition          "color .1s ease"
-                  :color               "rgba(0,0,0,.87)"}
-                 active?
-                 (merge {:border-bottom "2px solid #c10e12"
-                         :font-weight   600}))}
+  [:a {:href  href
+       :style (cond->
+                {:align-self          :flex-end
+                 :margin              "0 0 -2px"
+                 :padding             ".85714286em 1.14285714em"
+                 :border-bottom-width "2px"
+                 :transition          "color .1s ease"
+                 :color               "rgba(0,0,0,.87)"}
+                active?
+                (merge {:border-bottom "2px solid #c10e12"
+                        :font-weight   600}))}
    icon
    label])
 
@@ -56,6 +56,7 @@
 (defn DeploymentsMainContent
   []
   (let [route-name          (subscribe [::routing-subs/route-name])
+        uuid                (subscribe [::routing-subs/path-param :uuid])
         depl-group-enabled? (subscribe [::about-subs/feature-flag-enabled? about-utils/feature-deployment-set-key])]
     (fn []
       (case @route-name
@@ -64,7 +65,9 @@
         (::routes/deployment-set ::routes/deployment-sets) (dispatch [::deployment-sets-events/refresh])
 
         (::routes/deployment-groups-details ::routes/deployment-sets-details)
-        (dispatch [::dsd-events/init])
+        (if (= "create" @uuid)
+          (dispatch [::dsd-events/init-create])
+          (dispatch [::dsd-events/init]))
 
         nil)
       [:<>

--- a/code/src/cljs/sixsq/nuvla/ui/routing/subs.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/routing/subs.cljs
@@ -41,6 +41,11 @@
   :<- [::current-route]
   :-> :path-params)
 
+(reg-sub
+  ::path-param
+  :<- [::path-params]
+  (fn [path-params [_ path-param-key]]
+    (get path-params path-param-key)))
 
 (reg-sub
   ::query-param


### PR DESCRIPTION
Fixes SixSq/tasklist#2744
