### PR TITLE
Do not refetch DG group edges during creation

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/deployment_sets_detail/spec.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/deployment_sets_detail/spec.cljs
@@ -7,7 +7,9 @@
 (s/def ::deployment-set (s/nilable any?))
 (s/def ::deployment-set-edited (s/nilable any?))
 
+;; ::edges db path will contain the ids of the edges which are part of the deployment set
 (s/def ::edges (s/coll-of map? :kind vector?))
+;; ::edges-documents db path will contain the edges documents to show, after filtering and pagination
 (s/def ::edges-documents (s/coll-of map? :kind vector?))
 (s/def ::edges-full-text-search (s/nilable string?))
 (s/def ::edges-ordering (s/coll-of (s/cat :field keyword? :order #{"desc" "asc" :desc :asc})))

--- a/code/src/cljs/sixsq/nuvla/ui/deployment_sets_detail/subs.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/deployment_sets_detail/subs.cljs
@@ -286,6 +286,10 @@
 
 
 (defn current-route->edges-db-path
+  "Db path that will contain the ids of the selected edges, before any filtering and pagination.
+   During creation the path will be of the form [::spec/edges <temp-id>],
+   while during editing it will be just [::spec/edges].
+   Note that filtered and paginated documents are stored under ::spec/edges-documents instead."
   [current-route]
   (create-db-path [::spec/edges]
                   (get-temp-db-id current-route)))

--- a/code/src/cljs/sixsq/nuvla/ui/deployment_sets_detail/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/deployment_sets_detail/views.cljs
@@ -1639,10 +1639,10 @@
        true true])))
 
 (defn- EdgeTabStatesFilter
-  []
+  [_creating?]
   (let [selected-state (subscribe [::route-subs/query-param events/edges-state-filter-key])]
-    (fn []
-      (dispatch [::events/get-edges])
+    (fn [creating?]
+      (dispatch [::events/get-edges creating?])
       [EdgeTabStatesFilterView @selected-state])))
 
 (defn EdgesTabView
@@ -1693,7 +1693,7 @@
         [ui/GridColumn {:width 7}
          [:div {:class :nuvla-edges
                 :style {:margin "0 auto 0 6rem"}}
-          [EdgeTabStatesFilter]]]]
+          [EdgeTabStatesFilter creating?]]]]
        (when @fleet-changes
          [:div {:style {:margin-top    "1rem"
                         :margin-bottom "1rem"}}
@@ -1713,7 +1713,7 @@
                               (:resources @edges))
            :columns     columns
            :sort-config {:db-path     ::spec/edges-ordering
-                         :fetch-event [::events/get-edges]}}
+                         :fetch-event [::events/get-edges creating?]}}
           (and @can-edit-data? (not @fleet-filter))
           (assoc :select-config {:disabled-tooltip    (edit-not-allowed-msg
                                                         {:TR                         @tr
@@ -1730,7 +1730,7 @@
                                  :select-db-path      [::spec/edges-select]}))]
        [pagination-plugin/Pagination
         {:db-path                [::spec/edges-pagination]
-         :change-event           [::events/get-edges]
+         :change-event           [::events/get-edges creating?]
          :total-items            (-> @edges :count)
          :i-per-page-multipliers [1 2 4]}]
        [FleetFilterPanel {:show-edit-filter-button? false :creating? creating?}]])))


### PR DESCRIPTION
Fixes SixSq/tasklist#2790
