### PR TITLE
Fix display of 'Last boot' time on NuvlaEdge page

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/edges_detail/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/edges_detail/views.cljs
@@ -1115,6 +1115,7 @@
 (defn HostInfo
   [_nb-status _ssh-creds]
   (let [tr       (subscribe [::i18n-subs/tr])
+        locale    (subscribe [::i18n-subs/locale])
         show-ips (r/atom false)]
     (fn [{:keys [hostname ip docker-server-version network
                  operating-system architecture last-boot docker-plugins]
@@ -1187,7 +1188,7 @@
           (when last-boot
             [ui/TableRow
              [ui/TableCell (str/capitalize (@tr [:last-boot]))]
-             [ui/TableCell (time/time->format last-boot)]])
+             [ui/TableCell (time/parse-ago last-boot @locale)]])
           (let [interfaces   (:interfaces network)
                 n-interfaces (count interfaces)
                 n-ips        (reduce + (map (comp count :ips) interfaces))]


### PR DESCRIPTION
Solves https://github.com/SixSq/tasklist/issues/2415

- Changes the 'Last boot' time to display how much time has passed since last boot.