### PR TITLE
Deployments tab should be empty during DG creation

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/deployment_sets_detail/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/deployment_sets_detail/events.cljs
@@ -301,7 +301,7 @@
 (reg-event-fx
   ::get-deployments-for-deployment-sets
   (fn [{{:keys [current-route]} :db} [_ uuid]]
-    (when uuid
+    (if uuid
       (let [query-filter      (routing-utils/get-query-param current-route deployments-state-filter-key)
             filter-constraint (str "deployment-set='" (uuid->depl-set-id uuid) "'")]
         {:fx [[:dispatch [::deployments-events/get-deployments
@@ -310,7 +310,9 @@
                                                     (deployments-utils/state-filter query-filter))
                            :external-filter-only? true
                            :pagination-db-path    ::spec/pagination-deployments}]]
-              [:dispatch [::deployments-events/get-deployments-summary-all filter-constraint]]]}))))
+              [:dispatch [::deployments-events/get-deployments-summary-all filter-constraint]]]})
+      {:fx [[:dispatch [::deployments-events/reset-deployments]]
+            [:dispatch [::deployments-events/reset-deployments-summary-all]]]})))
 
 (reg-event-db
   ::set-deployment-set-edited

--- a/code/src/cljs/sixsq/nuvla/ui/deployments/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/deployments/events.cljs
@@ -52,6 +52,7 @@
     (assoc db ::spec/deployments-params-map
               (group-by :parent deployment-params))))
 
+
 (reg-event-fx
   ::set-deployments
   (fn [{:keys [db]} [_ {:keys [resources] :as deployments}]]
@@ -69,6 +70,11 @@
               (not-empty deployments-resource-ids) (assoc ::cimi-api-fx/search
                                                           [:deployment-parameter
                                                            query-params callback])))))
+
+(reg-event-fx
+  ::reset-deployments
+  (fn []
+    {:fx [[:dispatch [::set-deployments {:resources []}]]]}))
 
 (reg-event-fx
   ::get-deployments

--- a/code/src/cljs/sixsq/nuvla/ui/deployments/spec.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/deployments/spec.cljs
@@ -34,7 +34,7 @@
 (def default-ordering [[:created :desc]])
 
 (def defaults {::deployments-search      (full-text-search-plugin/build-spec)
-               ::additional-filter        nil
+               ::additional-filter       nil
                ::deployments             nil
                ::deployment-edges        nil
                ::deployments-summary     nil


### PR DESCRIPTION
Fixes SixSq/tasklist#2818
