### PR TITLE
Link application column in deployments table to deployment details instead of application details

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/deployments/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/deployments/views.cljs
@@ -183,13 +183,7 @@
                                                   [:img {:src   (or (:thumb-nail module) (:logo-url module))
                                                          :style {:width  "42px"
                                                                  :height "30px"}}]
-                                                  [module-plugin/LinkToAppView
-                                                   {:version-id (utils/get-version-number
-                                                                  (:versions module)
-                                                                  (:content module))
-                                                    :path       (:path module)
-                                                    :target     "_self"}
-                                                   [:div (:name module)]]])
+                                                  [:div (:name module)]])
                                :version        (utils/deployment-version deployment)
                                :status         state
                                :url            (when url
@@ -245,12 +239,11 @@
                        (mapv (fn [col]
                                (when col (assoc col :cell table-cell)))
                              [(when-not no-module-name
-                                {:field-key               :module.name
-                                 :cell-props              {:style {:overflow      "hidden",
-                                                                   :text-overflow "ellipsis",
-                                                                   :max-width     "20ch"}}
-                                 :header-content          (@tr [:module])
-                                 :stop-event-propagation? true})
+                                {:field-key      :module.name
+                                 :cell-props     {:style {:overflow      "hidden",
+                                                          :text-overflow "ellipsis",
+                                                          :max-width     "20ch"}}
+                                 :header-content (@tr [:module])})
                               {:field-key :version :no-sort? true}
                               {:field-key :status
                                :sort-key  :state}


### PR DESCRIPTION
Closes SixSq/tasklist#2855

