### PR TITLE
improve list of components to get logs

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/pages/apps/utils.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/pages/apps/utils.cljs
@@ -12,6 +12,7 @@
 (def subtype-component "component")
 (def subtype-application "application")
 (def subtype-application-k8s "application_kubernetes")
+(def subtype-application-helm "application_helm")
 (def subtype-applications-sets "applications_sets")
 
 (def apps-description-template "# App Description Placeholder

--- a/code/src/cljs/sixsq/nuvla/ui/pages/deployments_detail/subs.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/pages/deployments_detail/subs.cljs
@@ -104,6 +104,7 @@
       is-application-kubernetes? (some->> docker-compose
                                           parse-application-yaml
                                           (map only-k8s-workload-object-kinds)
+                                          (remove nil?)
                                           sort)
       is-application-helm? []
       :else [])))


### PR DESCRIPTION
- only k8s workload object kinds for the list of components to get logs
- none for helm or unknown app type

Test result. Only `Deployment` in the list

<img width="889" alt="Screenshot 2024-05-19 at 11 18 13" src="https://github.com/nuvla/ui/assets/353767/bf53ad11-006d-47b4-ade6-cd3165ba2a6c">


when `Service` is also present in the manifest:

```
apiVersion: v1
kind: Service
metadata:
  name: my-nginx-svc
  labels:
    app: nginx
spec:
  type: LoadBalancer
  ports:
  - port: 80
  selector:
    app: nginx
    
---

apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-nginx
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:latest
        ports:
        - containerPort: 80
 ```

Closes https://github.com/SixSq/tasklist/issues/3119 