### PR TITLE
fix(dg-overview-layout): use css grid for duration picker

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/common_components/plugins/duration_picker.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/common_components/plugins/duration_picker.cljs
@@ -30,11 +30,14 @@
   (let [opts-fn   (fn [vals] (map (fn [i] {:key i :value i :content i :text i}) vals))
         {:keys [days hours minutes seconds] :as value} (decompose-duration @!value)
         set-value #(set-value-fn (->seconds %))]
-    [:div {:style {:display     :flex
-                   :align-items :center
-                   :gap         5}}
+    [:div {:style {:display               :grid
+                   :grid-template-columns "repeat(auto-fill, minmax(100px, 1fr))"
+                   :align-items           :center
+                   :gap                   5}}
      (when @!show-days?
-       [:<>
+       [:div {:style {:display :flex
+                      :align-items           :center
+                      :gap 5}}
         [:label (tr-fn [:days])]
         [ui/Dropdown {:class     :duration-days
                       :value     days
@@ -43,7 +46,9 @@
                       :style     {:min-width "70px"}
                       :on-change (ui-callback/value #(set-value (assoc value :days %)))}]])
      (when @!show-hours?
-       [:<>
+       [:div {:style {:display :flex
+                      :align-items           :center
+                      :gap 5}}
         [:label (tr-fn [:hours])]
         [ui/Dropdown {:class     :duration-hours
                       :value     hours
@@ -52,7 +57,9 @@
                       :style     {:min-width "70px"}
                       :on-change (ui-callback/value #(set-value (assoc value :hours %)))}]])
      (when @!show-minutes?
-       [:<>
+       [:div {:style {:display :flex
+                      :align-items           :center
+                      :gap 5}}
         [:label (tr-fn [:minutes])]
         [ui/Dropdown {:class     :duration-minutes
                       :value     minutes
@@ -61,7 +68,9 @@
                       :style     {:min-width "70px"}
                       :on-change (ui-callback/value #(set-value (assoc value :minutes %)))}]])
      (when @!show-seconds?
-       [:<>
+       [:div {:style {:display :flex
+                      :align-items           :center
+                      :gap 5}}
         [:label (tr-fn [:seconds])]
         [ui/Dropdown {:class     :duration-seconds
                       :value     seconds

--- a/code/src/cljs/sixsq/nuvla/ui/pages/deployment_sets_detail/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/pages/deployment_sets_detail/views.cljs
@@ -688,11 +688,12 @@
                            :label    ""
                            :on-click #(dispatch [::events/set-auto-update (not auto-update)])}]
              [:div {:style {:display     :flex
+                            :width "90%"
                             :align-items :center
                             :gap         10
                             :visibility  (if auto-update :visible :hidden)}}
               [:span (str/capitalize (@tr [:interval])) ":"]
-              [:span
+              [:span {:style {:width "80%"}}
                [duration-picker/DurationPickerController
                 {:!value           !auto-update-interval-in-seconds
                  :set-value-fn     #(dispatch [::events/set-auto-update-interval %])


### PR DESCRIPTION
Fixes SixSq/tasklist#3415
