### PR TITLE
feat(Deployment group details page): Make name&desc fields directly editable

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/pages/deployment_sets_detail/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/pages/deployment_sets_detail/views.cljs
@@ -606,10 +606,10 @@
         on-change-fn     #(dispatch [::events/edit attribute %])]
     [ui/TableCell
      (if (and @can-edit-data? (or creating? @edit-op-allowed?))
-       [components/EditableInput
-        {:resource     @deployment-set
-         :attribute    attribute
-         :on-change-fn on-change-fn}]
+       [ui/Input
+        {:default-value (get @deployment-set attribute)
+         :on-change     (ui-callback/input-callback on-change-fn)
+         :style         {:width "100%"}}]
        (get @deployment-set attribute))]))
 
 (def ops-status->color

--- a/code/test/e2e/loggedin/create_depl_group_with_app.spec.ts
+++ b/code/test/e2e/loggedin/create_depl_group_with_app.spec.ts
@@ -27,13 +27,9 @@ test('create deployment group containing an app from deployment modal', async ({
 
   await page.waitForTimeout(1000);
 
-  await page.getByRole('cell', { name: /Deployment Group/ }).locator('i').click();
-
   await page.getByRole('row', { name: 'Name' }).locator('input[type="text"]').click();
 
   await page.getByRole('row', { name: 'Name' }).locator('input[type="text"]').fill(testDeplGroupName);
-
-  await page.getByRole('row', { name: 'Name' }).getByRole('button').click();
 
   await page.getByTestId('add-edges-button').click();
 

--- a/code/test/e2e/loggedin/depl-groups.spec.ts
+++ b/code/test/e2e/loggedin/depl-groups.spec.ts
@@ -19,13 +19,9 @@ test('test', async ({ page }, { config }) => {
 
   await expect(page).toHaveURL(new RegExp(`${baseURL}/ui/deployment-groups/create`));
 
-  await page.getByRole('row', { name: 'Name' }).locator('i').click();
-
   await page.getByRole('row', { name: 'Name' }).locator('input[type="text"]').click();
 
   await page.getByRole('row', { name: 'Name' }).locator('input[type="text"]').fill(testDeplGroupName);
-
-  await page.getByRole('row', { name: 'Name' }).getByRole('button').click();
 
   await expect(page).toHaveURL(new RegExp(`${baseURL}/ui/deployment-groups/create`));
 


### PR DESCRIPTION
Closes SixSq/tasklist#3432
