### PR TITLE
fix(select-fields-icon-render-bug): removing z-index from table select fields icon

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/common_components/plugins/table.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/common_components/plugins/table.cljs
@@ -790,8 +790,7 @@
                                :class    :table-select-fields-button
                                :style    {:padding    0
                                           :box-shadow :none
-                                          :position   :relative
-                                          :z-index    1000}
+                                          :position   :relative}
                                :on-click (fn []
                                            (reset! selected-cols (set @current-cols))
                                            (reset! show? true))}]}])))


### PR DESCRIPTION
Fixes SixSq/tasklist#3449
