### PR TITLE
fix(Apps details page): Switching between app version is not refreshi…

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/main/events.cljs
@@ -177,7 +177,7 @@
 
 (reg-event-fx
   ::do-not-ignore-changes
-  (fn [{{:keys [::spec/do-not-ignore-changes-modal] :as db} :db} _]
+  (fn [{{:keys [::spec/do-not-ignore-changes-modal] :as db} :db}]
     (let [base-fx        (if (::opened-by-browser-back db)
                            {:fx [[:dispatch [::routing-events/reset-ignore-changes-protection]]]}
                            {:fx (or (:fx do-not-ignore-changes-modal) [])})]
@@ -203,9 +203,17 @@
          :fx clear-fx}
 
         (fn? ignore-changes-modal)
-        (do (ignore-changes-modal)
+        (do
+          (ignore-changes-modal)
           {:db db-chng-unprtd
            :fx clear-fx})))))
+
+(reg-event-fx
+  ::changes-protected-f?
+  (fn [{{:keys [::spec/changes-protection?] :as db} :db} [_ f]]
+    (if changes-protection?
+      {:db (assoc db ::spec/ignore-changes-modal f)}
+      (f))))
 
 (reg-event-fx
   ::after-clear-event
@@ -237,13 +245,6 @@
   ::enable-browser-back
   (fn [_ [_ payload]]
     {:fx [[::fx/enable-browser-back payload]]}))
-
-
-
-(reg-event-db
-  ::ignore-changes-modal
-  (fn [db [_ callback-fn]]
-    (assoc db ::spec/ignore-changes-modal callback-fn)))
 
 (reg-event-fx
   ::set-notifications

--- a/code/src/cljs/sixsq/nuvla/ui/pages/apps/apps_application/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/pages/apps/apps_application/views.cljs
@@ -326,18 +326,14 @@
 
 (defn ConfigurationPane
   []
-  (let [module-content-id (subscribe [::apps-subs/module-content-id])]
-    (fn []
-      ;; make sure the configuration is refreshed on version change
-      ^{:key @module-content-id}
-      [:div {:class :uix-apps-details-details}
-       [:h4 {:class :tab-app-detail} [apps-views-detail/ConfigurationTitle]]
-       [apps-views-detail/EnvVariablesSection]
-       [FilesSection]
-       [apps-views-detail/UrlsSection]
-       [apps-views-detail/OutputParametersSection]
-       [apps-views-detail/RequirementsSection]
-       [apps-views-detail/DataTypesSection]])))
+  [:div {:class :uix-apps-details-details}
+   [:h4 {:class :tab-app-detail} [apps-views-detail/ConfigurationTitle]]
+   [apps-views-detail/EnvVariablesSection]
+   [FilesSection]
+   [apps-views-detail/UrlsSection]
+   [apps-views-detail/OutputParametersSection]
+   [apps-views-detail/RequirementsSection]
+   [apps-views-detail/DataTypesSection]])
 
 
 (defn TabMenuLicense

--- a/code/src/cljs/sixsq/nuvla/ui/pages/apps/views_detail.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/pages/apps/views_detail.cljs
@@ -103,7 +103,7 @@
     [uix/ModalDanger
      {:with-confirm-step? true
       :on-confirm         (fn [] (dispatch [::events/delete-module id]))
-      :trigger            (r/as-element [ui/MenuItem {:disabled (or @is-new? (seq (:children module)))}
+      :trigger            (r/as-element [ui/MenuItem {:disabled (or @is-new? (some? (seq (:children module))))}
                                          [icons/TrashIcon]
                                          (str/capitalize (@tr [:delete]))])
       :content            [:h3 content]
@@ -436,14 +436,16 @@
          [ui/Message {:warning true}
           [ui/MessageHeader (@tr [:warning])]
           [ui/MessageContent (@tr [:warning-draft-version-1])
-           [:a {:on-click #(dispatch [::events/get-module @latest-published-index])
+           [:a {:on-click (fn [] (dispatch [::main-events/changes-protected-f?
+                                            #(dispatch [::events/get-module @latest-published-index])]))
                 :style    {:cursor :pointer}} (@tr [:here])]
            (@tr [:warning-draft-version-2])]])
        (when (and (not @is-module-published?) (not @is-latest?))
          [ui/Message {:warning true}
           [ui/MessageHeader (@tr [:warning])]
           [ui/MessageContent (@tr [:warning-not-latest-version-1])
-           [:a {:on-click #(dispatch [::events/get-module -1])
+           [:a {:on-click (fn [] (dispatch [::main-events/changes-protected-f?
+                                            #(dispatch [::events/get-module -1])]))
                 :style    {:cursor :pointer}} (@tr [:here])]
            (@tr [:warning-not-latest-version-2])]])])))
 

--- a/code/src/cljs/sixsq/nuvla/ui/pages/apps/views_versions.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/pages/apps/views_versions.cljs
@@ -4,6 +4,7 @@
             [reagent.core :as reagent]
             [sixsq.nuvla.ui.common-components.i18n.subs :as i18n-subs]
             [sixsq.nuvla.ui.pages.apps.events :as events]
+            [sixsq.nuvla.ui.main.events :as main-events]
             [sixsq.nuvla.ui.pages.apps.subs :as subs]
             [sixsq.nuvla.ui.utils.general :as general-utils]
             [sixsq.nuvla.ui.utils.icons :as icons]
@@ -117,8 +118,7 @@
 
 
 (defn Versions []
-  (let [tr              (subscribe [::i18n-subs/tr])
-        versions        (subscribe [::subs/versions])
+  (let [versions        (subscribe [::subs/versions])
         current-version (subscribe [::subs/module-content-id])]
     (fn []
       [:div {:class :uix-apps-details-details}
@@ -129,5 +129,5 @@
             [:div
              [versions-compare @versions]])
           [versions-table versions current-version
-           :on-click #(dispatch [::events/get-module %])]]
+           :on-click (fn [v] (dispatch [::main-events/changes-protected-f? #(dispatch [::events/get-module v])]))]]
          [uix/MsgNoItemsToShow [uix/TR :no-versions]])])))

--- a/code/src/cljs/sixsq/nuvla/ui/session/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/session/events.cljs
@@ -199,14 +199,12 @@
 
 (reg-event-fx
   ::switch-group
-  (fn [{{:keys [::spec/session ::main-spec/changes-protection?] :as db} :db} [_ claim extended]]
-    (if changes-protection?
-      {:db (assoc db ::main-spec/ignore-changes-modal {:fx [[:dispatch [::switch-group claim extended]]]})}
-      (let [claim    (if (= (session-utils/get-identifier session) claim) (session-utils/get-user-id session) claim)
-            data     {:claim    claim
-                      :extended extended}
-            callback #(dispatch [::initialize])]
-        {::cimi-api-fx/operation [(:id session) "switch-group" callback :on-error callback :data data]}))))
+  (fn [{{:keys [::spec/session] } :db} [_ claim extended]]
+    (let [claim    (if (= (session-utils/get-identifier session) claim) (session-utils/get-user-id session) claim)
+          data     {:claim    claim
+                    :extended extended}
+          callback #(dispatch [::initialize])]
+      {::cimi-api-fx/operation [(:id session) "switch-group" callback :on-error callback :data data]})))
 
 
 (reg-event-db

--- a/code/src/cljs/sixsq/nuvla/ui/session/views.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/session/views.cljs
@@ -4,6 +4,7 @@
             [reagent.core :as r]
             [sixsq.nuvla.ui.common-components.i18n.subs :as i18n-subs]
             [sixsq.nuvla.ui.main.subs :as main-subs]
+            [sixsq.nuvla.ui.main.events :as main-events]
             [sixsq.nuvla.ui.routing.events :as routing-events]
             [sixsq.nuvla.ui.routing.routes :as routes]
             [sixsq.nuvla.ui.routing.subs :as route-subs]
@@ -23,7 +24,9 @@
         search       (r/atom "")
         open         (r/atom false)
         cursor       (r/atom 0)
-        on-click     #(dispatch [::events/switch-group % @extended?])
+        on-click     (fn [claim]
+                       (dispatch [::main-events/changes-protected-f?
+                                  #(dispatch [::events/switch-group claim @extended?])]))
         options      (subscribe [::subs/switch-group-options])
         tr           (subscribe [::i18n-subs/tr])
         is-mobile?   (subscribe [::main-subs/is-mobile-device?])
@@ -106,9 +109,11 @@
                {:text     (@tr [:show-subgroups-resources])
                 :icon     (str (when @extended? "check ")
                                icons/i-square-outline)
-                :on-click #(do (swap! extended? not)
-                               (on-click @active-claim)
-                               (.stopPropagation %))}]])])))))
+                :on-click (fn [event]
+                            (dispatch [::main-events/changes-protected-f?
+                                       #(do (swap! extended? not)
+                                            (on-click @active-claim)
+                                            (.stopPropagation event))]))}]])])))))
 
 
 (defn UserMenuItem


### PR DESCRIPTION
…ng helm fields

fix(Apps details page): Switching between generalize key to reload on module content change
fix(Apps details page): Ask user if he wants to ignore ongoing changes when switching to different app version
fix(Apps details page): Warning delete button disabled prop should be a boolean fix