### PR TITLE
fix(dg-creation-no-error-notifs): show error notifications during DG creation phase

### DIFF
--- a/code/src/cljs/sixsq/nuvla/ui/pages/deployment_sets_detail/events.cljs
+++ b/code/src/cljs/sixsq/nuvla/ui/pages/deployment_sets_detail/events.cljs
@@ -611,9 +611,15 @@
                  ;; as we navigate away from the page and we don't want to re-enable the save button.
                  (dispatch [::routing-events/navigate routes/deployment-groups-details
                             {:uuid (general-utils/id->uuid (:resource-id %))}]))
-              :on-error (fn []
+              :on-error (fn [response]
                           (dispatch [::set-changes-protection true])
-                          (dispatch [::set ::spec/persist-in-progress? false]))]]]})))
+                          (dispatch [::set ::spec/persist-in-progress? false])
+                          (let [{:keys [status message]} (response/parse-ex-info response)]
+                            (dispatch [::messages-events/add
+                                       {:header  (cond-> (str "error creating deployment group")
+                                                         status (str " (" status ")"))
+                                        :content message
+                                        :type    :error}])))]]]})))
 
 (defn overwritten-app-version
   [deployment-set app]


### PR DESCRIPTION
Fixes SixSq/tasklist#3463
